### PR TITLE
fix(site): repair SEO metadata and article layout

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://placona.co.uk/sitemap-index.xml

--- a/scripts/migrate-jekyll-posts.mjs
+++ b/scripts/migrate-jekyll-posts.mjs
@@ -30,12 +30,59 @@ function sanitiseDuplicateFrontmatter(raw) {
   return `${match[1]}${header}${match[3]}${raw.slice(match[0].length)}`;
 }
 
-function normaliseBody(body) {
-  return body
+function cleanText(value) {
+  return value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`>#]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function deriveDescription(body, title) {
+  for (const block of body.split(/\n\s*\n/)) {
+    const text = cleanText(block);
+    if (text.length >= 50 && !text.startsWith('```')) {
+      return text.length > 156 ? `${text.slice(0, 153).replace(/\s+\S*$/, '')}…` : text;
+    }
+  }
+  return `Read Marcos Placona’s article: ${title}.`;
+}
+
+function titleKey(value) {
+  return cleanText(value.toLocaleLowerCase('en-GB').replace(/[’']s\b/g, ''))
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function normaliseBody(body, title) {
+  const replacements = body
     .replaceAll('{% post_url 2020/2020-03-15-modern-android-development %}', '/modern-android-development/')
     .replaceAll('{% include youtubePlayer.html id="p3gcD0Jdqe0" %}', '<iframe title="YouTube video" src="https://www.youtube-nocookie.com/embed/p3gcD0Jdqe0" loading="lazy" allowfullscreen></iframe>')
     .replace(/\{:target="_blank"\}/g, '')
     .replace(/\{\{\s*'([^']+)'\s*\|\s*relative_url\s*\}\}/g, '$1');
+
+  let inCodeBlock = false;
+  const lines = replacements.split('\n').map((line) => {
+    if (line.trimStart().startsWith('```')) inCodeBlock = !inCodeBlock;
+    return !inCodeBlock && /^#\s+/.test(line) ? line.replace(/^#\s+/, '## ').trimEnd() : line;
+  });
+
+  const firstMeaningfulIndex = lines.findIndex((line) => line.trim() !== '');
+  if (firstMeaningfulIndex >= 0) {
+    const firstHeading = lines[firstMeaningfulIndex].match(/^##\s+(.+)$/);
+    if (firstHeading) {
+      const headingKey = titleKey(firstHeading[1]);
+      const articleTitleKey = titleKey(title);
+      if (headingKey === articleTitleKey || headingKey.endsWith(articleTitleKey) || articleTitleKey.endsWith(headingKey)) {
+        lines.splice(firstMeaningfulIndex, 1);
+        if (lines[firstMeaningfulIndex] === '') lines.splice(firstMeaningfulIndex, 1);
+      }
+    }
+  }
+
+  return lines.join('\n');
 }
 
 fs.rmSync(outputRoot, { recursive: true, force: true });
@@ -48,13 +95,13 @@ for (const sourcePath of files) {
   const slug = filename.replace(/^\d{4}-\d{2}-\d{2}-/, '');
   const data = parsed.data;
   const title = data.title ?? slug.replaceAll('-', ' ');
-  const description = data.excerpt ?? '';
+  const description = cleanText(data.excerpt ?? '') || deriveDescription(parsed.content, title);
   const date = data.date ?? `${filename.slice(0, 10)}T00:00:00.000Z`;
   const categories = Array.isArray(data.categories) ? data.categories : data.categories ? [data.categories] : [];
   const tags = Array.isArray(data.tags) ? data.tags : data.tags ? [data.tags] : [];
   const image = data.image ? `image: ${yaml('/' + String(data.image).replace(/^\//, ''))}\n` : '';
   const frontmatter = `---\ntitle: ${yaml(title)}\ndescription: ${yaml(description)}\npubDate: ${yaml(new Date(date).toISOString())}\nslug: ${yaml(slug)}\ncategories: ${yaml(categories)}\ntags: ${yaml(tags)}\n${image}draft: false\n---\n\n`;
-  fs.writeFileSync(path.join(outputRoot, `${slug}.md`), frontmatter + normaliseBody(parsed.content));
+  fs.writeFileSync(path.join(outputRoot, `${slug}.md`), frontmatter + normaliseBody(parsed.content, title));
 }
 
 console.log(`Migrated ${files.length} published posts to ${outputRoot}`);

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -6,7 +6,7 @@ const blog = defineCollection({
   loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
   schema: z.object({
     title: z.string(),
-    description: z.string().default(''),
+    description: z.string().min(1),
     pubDate: z.coerce.date(),
     slug: z.string(),
     image: z.string().optional(),

--- a/src/content/blog/10-dropbox-invites.md
+++ b/src/content/blog/10-dropbox-invites.md
@@ -1,6 +1,6 @@
 ---
 title: "10 Dropbox Invites"
-description: ""
+description: "Just a quick post to say that I have 10 7 dropbox invites I'm willing to give to anyone able to tell me why I should give it away."
 pubDate: "2008-09-10T00:00:00.000Z"
 slug: "10-dropbox-invites"
 categories: ["Technology"]

--- a/src/content/blog/a-change-is-always-welcome.md
+++ b/src/content/blog/a-change-is-always-welcome.md
@@ -1,6 +1,6 @@
 ---
 title: "A change is always welcome"
-description: ""
+description: "I've been procrastinating for too long, and somehow trying to avoid the inevitable. As must of you might have noticed, it's been a long time I don't…"
 pubDate: "2010-04-28T11:00:59.000Z"
 slug: "a-change-is-always-welcome"
 categories: ["Technology"]

--- a/src/content/blog/a-few-new-year-s-resolutions.md
+++ b/src/content/blog/a-few-new-year-s-resolutions.md
@@ -1,6 +1,6 @@
 ---
 title: "A few new year's resolutions"
-description: ""
+description: "Well, I've never publicly done this before, as I though it was a little too personal, but this year I decided to try it."
 pubDate: "2008-12-31T00:00:00.000Z"
 slug: "a-few-new-year-s-resolutions"
 categories: ["Misc"]

--- a/src/content/blog/a-first-look-at-dart.md
+++ b/src/content/blog/a-first-look-at-dart.md
@@ -1,6 +1,6 @@
 ---
 title: "A first look at Dart"
-description: ""
+description: "A few weeks ago, I went to a Google sponsored event called Dart Flight School. The aim is to promote the language by doing a road trip and presenting…"
 pubDate: "2014-03-12T08:28:10.000Z"
 slug: "a-first-look-at-dart"
 categories: ["Dart"]

--- a/src/content/blog/a-more-elaborated-jquery-drag-drop-cloning.md
+++ b/src/content/blog/a-more-elaborated-jquery-drag-drop-cloning.md
@@ -1,6 +1,6 @@
 ---
 title: "A more elaborated jQuery Drag & Drop (with cloning)"
-description: ""
+description: "I've decided to get back at jQuery draggable and droppable to a personal project I've been working on. In the past, I've demonstrated how to do basic…"
 pubDate: "2009-08-21T00:00:00.000Z"
 slug: "a-more-elaborated-jquery-drag-drop-cloning"
 categories: ["Javascript"]

--- a/src/content/blog/adobe-air-1-5-1-released.md
+++ b/src/content/blog/adobe-air-1-5-1-released.md
@@ -1,6 +1,6 @@
 ---
 title: "Adobe AIR 1.5.1 released"
-description: ""
+description: "I know I'm a bit late on this one, but yesterday Adobe released AIR 1.5.1 with a few bug fixes and one \"minor-albeit useful-new feature.\" as they say."
 pubDate: "2009-02-25T00:00:00.000Z"
 slug: "adobe-air-1-5-1-released"
 categories: ["Adobe"]

--- a/src/content/blog/android-and-what-ive-been-up-to.md
+++ b/src/content/blog/android-and-what-ive-been-up-to.md
@@ -1,6 +1,6 @@
 ---
 title: "Android and what I've been up to"
-description: ""
+description: "I jumped into the Android bandwagon about two months ago, and so far I can't cease to be impressed."
 pubDate: "2010-07-27T16:20:18.000Z"
 slug: "android-and-what-ive-been-up-to"
 categories: ["Android"]

--- a/src/content/blog/android-jetpack-and-lifecycles.md
+++ b/src/content/blog/android-jetpack-and-lifecycles.md
@@ -13,7 +13,7 @@ Handling [configuration changes](https://developer.android.com/guide/topics/reso
 
 Historically it's been common practice to use [`onSaveInstanceState`](https://developer.android.com/guide/components/activities/activity-lifecycle#save-simple,-lightweight-ui-state-using-onsaveinstancestate) so your data survived configuration changes. The drawback to this is that using this doesn't allow for storing [much data about the view](https://stackoverflow.com/questions/9805441/onsaveinstancestate-limit). 
 
-# The problem
+## The problem
 Let's look at an example app that we've built that generates a random number between 1 and 42 when the application starts.
 
 Running that application should give us a result like this:
@@ -34,7 +34,7 @@ Turning the device sideways should also give us that same result... right? Not r
 
 While this is just a simple application and the data here could very easily be stored inside `onSaveInstanceState`, if we have a lot of data showing on the screen, this solution would be less than robust and limited to the amount of data we can save.
 
-# The solution
+## The solution
 When an activity is created or recreated, it handles a few different tasks such as 
 
 - displaying the UI

--- a/src/content/blog/android-where-is-my-menu-button.md
+++ b/src/content/blog/android-where-is-my-menu-button.md
@@ -1,6 +1,6 @@
 ---
 title: "Android - Where is my menu button?"
-description: ""
+description: "So you’ve created your super polished android application and added a navigation menu to it, so your users can go from a place to another in your…"
 pubDate: "2013-02-09T22:16:54.000Z"
 slug: "android-where-is-my-menu-button"
 categories: ["Android"]

--- a/src/content/blog/apache-101-are-you-rotating-your-logs.md
+++ b/src/content/blog/apache-101-are-you-rotating-your-logs.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache 101 - Are you rotating your logs?"
-description: ""
+description: "It came to my attention today that my website was serving blank pages, and I got really intrigued with it. I checked the memory, and everything was…"
 pubDate: "2009-06-04T00:00:00.000Z"
 slug: "apache-101-are-you-rotating-your-logs"
 categories: ["VPS"]

--- a/src/content/blog/apache-101-avoiding-duplicate-content-on-your-domain.md
+++ b/src/content/blog/apache-101-avoiding-duplicate-content-on-your-domain.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache 101 - Avoiding duplicate content on your domain."
-description: ""
+description: "Did you know that search engines consider things like https://www.placona.co.uk/index.cfm and https://placona.co.uk/index.cfm as duplicate content? It…"
 pubDate: "2009-05-29T00:00:00.000Z"
 slug: "apache-101-avoiding-duplicate-content-on-your-domain"
 categories: ["VPS"]

--- a/src/content/blog/apache-101-cache-control.md
+++ b/src/content/blog/apache-101-cache-control.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache 101 - Cache Control"
-description: ""
+description: "Continuing with my Apache series, I'll be today talking about cache control."
 pubDate: "2009-04-30T00:00:00.000Z"
 slug: "apache-101-cache-control"
 categories: ["Technology"]

--- a/src/content/blog/apache-101-case-insensitive-url-s.md
+++ b/src/content/blog/apache-101-case-insensitive-url-s.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache 101 & Case insensitive URL's"
-description: ""
+description: "This is only a quick Apache tip for when you are using modrewrite."
 pubDate: "2009-05-21T00:00:00.000Z"
 slug: "apache-101-case-insensitive-url-s"
 categories: ["Linux"]

--- a/src/content/blog/apache-101-compressing-files.md
+++ b/src/content/blog/apache-101-compressing-files.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache 101 - Compressing Files"
-description: ""
+description: "I'm going to start a server configuration series here, where I'll be talking about my goals and frustrations when configuring my own webserver. As most…"
 pubDate: "2009-04-28T00:00:00.000Z"
 slug: "apache-101-compressing-files"
 categories: ["Technology"]

--- a/src/content/blog/as3-my-own-implementation-of-capfirst.md
+++ b/src/content/blog/as3-my-own-implementation-of-capfirst.md
@@ -1,6 +1,6 @@
 ---
 title: "AS3 my own implementation of capFirst()"
-description: ""
+description: "I'm just studying a little bit of Flex and Action Script 3. Basically to be able to build some tiny gadgets using Apollo."
 pubDate: "2007-03-21T00:00:00.000Z"
 slug: "as3-my-own-implementation-of-capfirst"
 categories: ["Adobe"]

--- a/src/content/blog/auto-generating-dtds.md
+++ b/src/content/blog/auto-generating-dtds.md
@@ -1,6 +1,6 @@
 ---
 title: "Auto-Generating DTDs"
-description: ""
+description: "I've used this DTD generator tool a long time ago, but today I had to use it again, so I thought I should put an entry on my blog about it and keep it…"
 pubDate: "2009-08-05T00:00:00.000Z"
 slug: "auto-generating-dtds"
 categories: ["Technology"]

--- a/src/content/blog/background-colour-in-a-label-control-in-as3.md
+++ b/src/content/blog/background-colour-in-a-label-control-in-as3.md
@@ -1,6 +1,6 @@
 ---
 title: "Background colour in a label control in AS3"
-description: ""
+description: "This is just a quick example of how to add a background colour to a label control in AS3."
 pubDate: "2011-06-27T22:33:52.000Z"
 slug: "background-colour-in-a-label-control-in-as3"
 categories: ["Adobe"]

--- a/src/content/blog/boost-domain-rating.md
+++ b/src/content/blog/boost-domain-rating.md
@@ -10,8 +10,6 @@ draft: false
 ---
 
 
-## How to Boost Your Website's Domain Rating with Redirects and Bot Control
-
 When you’re managing multiple domains, especially if you’re working on SEO for projects like I am, it’s important to take full advantage of the traffic your domains generate. After seeing [Oliver Fish's post](https://x.com/_Oliver_Fish/status/1844947412697190459) on how to make links from your directory/website look more valuable? I decided to give this a go and see how I could increase the DR for [MicroWidgets](https://MicroWidgets.dev) like that.
 
 <img class="alignnone size-full" src="/images/2024/10/oliver-fish-post.png" alt="Oliver Fish talking about how to increase website DR" />

--- a/src/content/blog/breaking-the-network.md
+++ b/src/content/blog/breaking-the-network.md
@@ -1,6 +1,6 @@
 ---
 title: "Breaking the network?"
-description: ""
+description: "I recently bought a brand new Compaq Presario desktop to my new flat. For the first week living there I was just using my laptop (also a Compaq…"
 pubDate: "2006-12-05T00:00:00.000Z"
 slug: "breaking-the-network"
 categories: ["Misc"]

--- a/src/content/blog/building-a-beautifully-smart-form-in-android-using-rxjava.md
+++ b/src/content/blog/building-a-beautifully-smart-form-in-android-using-rxjava.md
@@ -1,6 +1,6 @@
 ---
 title: "Building a beautifully smart form in Android using RxJava"
-description: ""
+description: "I don't think I know a single Android developer who's not stoked about Reactive Programming with RxAndroid right now. I totally dig the idea of…"
 pubDate: "2016-11-13T10:05:59.000Z"
 slug: "building-a-beautifully-smart-form-in-android-using-rxjava"
 categories: ["Android"]

--- a/src/content/blog/building-a-video-recording-application-in-android-with-camerax.md
+++ b/src/content/blog/building-a-video-recording-application-in-android-with-camerax.md
@@ -13,7 +13,7 @@ Recording videos in Android used to be a very involved task where it was necessa
 
 With the introduction of [CameraX](https://developer.android.com/jetpack/androidx/releases/camerax) to [Android Jetpack](https://developer.android.com/jetpack), it only takes a few lines of code to get that going. Let's build a video recording application.
 
-# Setup
+## Setup
 > You can download the code for this project in [this repository](https://github.com/mplacona/Droidagram) if you just want to see it running and not follow along.
 
 In Android Studio create a new project with an empty activity.
@@ -71,7 +71,7 @@ If you run this application now you will see something similar to this:
 
 <img class="alignnone size-full" src="/images/2019/05/camerax-03.png" alt="First run of the video recording app" />
 
-# Adding the camera preview
+## Adding the camera preview
 To be able to preview the camera, we need to request the permissions first. We do that going to `MainActivity.kt` and adding a couple of constants just before our `class`.
 
 ```java
@@ -160,7 +160,7 @@ CameraX.bindToLifecycle(this, preview)
 ```
 The code above is all you need to preview the camera. If you run the application now, it turns the camera on for your device or emulator. Now is a good time to try this out and see if everything is configured correctly.
 
-# Programming the button
+## Programming the button
 I wanted this button to only record when I held it pressed, and for it to stop recording when released. Let's add this logic inside the `onCreate` just before the end of the method.
 
 ```java
@@ -176,7 +176,7 @@ captureButton.setOnTouchListener { _, event ->
 ```
 Holding the button changes the background colour of it, and releasing brings it back to its original colour.
 
-# Recording videos
+## Recording videos
 Now we're ready to record our videos. Just before the logic for the button, add the following variable, so we get a location and a file name to save our recording.
 
 ```java

--- a/src/content/blog/changing-authentication-settings-tortoisesvn.md
+++ b/src/content/blog/changing-authentication-settings-tortoisesvn.md
@@ -1,6 +1,6 @@
 ---
 title: "Changing authentication settings on TortoiseSVN"
-description: ""
+description: "I've had my virtual machine (the one I use for development) rebuilt today, and to minimize overhead, we simply cloned a VM that had the desired settings."
 pubDate: "2010-06-17T12:51:48.000Z"
 slug: "changing-authentication-settings-tortoisesvn"
 categories: ["Technology"]

--- a/src/content/blog/creating-files-with-dart.md
+++ b/src/content/blog/creating-files-with-dart.md
@@ -1,6 +1,6 @@
 ---
 title: "Creating files with Dart"
-description: ""
+description: "This is a very simple example of how to create files with Dart. I am working on another example that involves file manipulation, but thought I'd quickly…"
 pubDate: "2014-05-03T23:23:43.000Z"
 slug: "creating-files-with-dart"
 categories: ["Dart"]

--- a/src/content/blog/dart-futures-and-http-requests.md
+++ b/src/content/blog/dart-futures-and-http-requests.md
@@ -1,6 +1,6 @@
 ---
 title: "Dart - Futures and HTTP requests"
-description: ""
+description: "I wrote a little article about how to retrieve gists from GitHub, and +Seth Ladd quite rightly pointed something out."
 pubDate: "2014-04-29T20:14:51.000Z"
 slug: "dart-futures-and-http-requests"
 categories: ["Dart"]

--- a/src/content/blog/dart-pub-packages-stats.md
+++ b/src/content/blog/dart-pub-packages-stats.md
@@ -1,6 +1,6 @@
 ---
 title: "Dart Pub packages stats"
-description: ""
+description: "Modulecounts came to my attention, and I thought the idea was pretty neat."
 pubDate: "2014-07-21T15:56:38.000Z"
 slug: "dart-pub-packages-stats"
 categories: ["Dart"]

--- a/src/content/blog/date-formatting-with-flex.md
+++ b/src/content/blog/date-formatting-with-flex.md
@@ -1,6 +1,6 @@
 ---
 title: "Date Formatting with Flex"
-description: ""
+description: "I've been working with some Adobe Flex recently, and was having some trouble formatting dates. For those who don't know, here (in th UK) we use the…"
 pubDate: "2009-12-08T00:00:00.000Z"
 slug: "date-formatting-with-flex"
 categories: ["Adobe"]

--- a/src/content/blog/e4x-and-xml-with-namespaces.md
+++ b/src/content/blog/e4x-and-xml-with-namespaces.md
@@ -1,6 +1,6 @@
 ---
 title: "E4X and XML with namespaces"
-description: ""
+description: "Here's is something that got me scratching my head for a little while today while working on my new mobile application."
 pubDate: "2011-09-04T22:05:36.000Z"
 slug: "e4x-and-xml-with-namespaces"
 categories: ["Android"]

--- a/src/content/blog/easy-unsubscribe-with-gounsubscribe-me.md
+++ b/src/content/blog/easy-unsubscribe-with-gounsubscribe-me.md
@@ -1,6 +1,6 @@
 ---
 title: "Easy unsubscribe with GoUnsubscribe.me"
-description: ""
+description: "I've created a new website over the last weekend and would like to share it here with you."
 pubDate: "2013-08-28T09:06:42.000Z"
 slug: "easy-unsubscribe-with-gounsubscribe-me"
 categories: ["Technology"]

--- a/src/content/blog/enterprise-queuing-applications.md
+++ b/src/content/blog/enterprise-queuing-applications.md
@@ -1,6 +1,6 @@
 ---
 title: "Enterprise queuing applications"
-description: ""
+description: "At work, we've decided to start using enterprise queuing applications for ease of communication between our ColdFusion and .Net projects."
 pubDate: "2012-07-29T12:30:00.000Z"
 slug: "enterprise-queuing-applications"
 categories: ["dotnet"]

--- a/src/content/blog/finite-image-slider.md
+++ b/src/content/blog/finite-image-slider.md
@@ -1,6 +1,6 @@
 ---
 title: "Finite image slider"
-description: ""
+description: "I've been asked to come up with an image slider prototype for something new we were doing at work."
 pubDate: "2012-08-26T00:08:25.000Z"
 slug: "finite-image-slider"
 categories: ["Javascript"]

--- a/src/content/blog/first-flex-4-book-released.md
+++ b/src/content/blog/first-flex-4-book-released.md
@@ -1,6 +1,6 @@
 ---
 title: "First Flex 4 book released"
-description: ""
+description: "The first Flex 4 book (Hello! Flex 4) has just been released this month in the UK. I haven't read it yet, so no way I could give any reviews on it, but…"
 pubDate: "2009-12-24T00:00:00.000Z"
 slug: "first-flex-4-book-released"
 categories: ["Flex"]

--- a/src/content/blog/flash-on-the-iphone.md
+++ b/src/content/blog/flash-on-the-iphone.md
@@ -1,6 +1,6 @@
 ---
 title: "Flash on the iPhone"
-description: ""
+description: "Not really Flash running from websites on the browser, but at the MAX Conference 2009 that is happening this week, Adobe has just broken the news that…"
 pubDate: "2009-10-05T00:00:00.000Z"
 slug: "flash-on-the-iphone"
 categories: ["Technology"]

--- a/src/content/blog/flash-player-for-linux.md
+++ b/src/content/blog/flash-player-for-linux.md
@@ -1,6 +1,6 @@
 ---
 title: "Flash player for Linux"
-description: ""
+description: "They finally made it! Adobe just released the Flash Player for Linux."
 pubDate: "2007-01-17T00:00:00.000Z"
 slug: "flash-player-for-linux"
 categories: ["Linux"]

--- a/src/content/blog/full-google-mail-smtp-power-for-your-domain.md
+++ b/src/content/blog/full-google-mail-smtp-power-for-your-domain.md
@@ -1,6 +1,6 @@
 ---
 title: "Full Google Mail / SMTP power for your domain"
-description: ""
+description: "I've recently been playing with Google apps for domains, where it lets you create Gmail based emails for your domain. Basically you can configure Google…"
 pubDate: "2009-05-07T00:00:00.000Z"
 slug: "full-google-mail-smtp-power-for-your-domain"
 categories: ["Technology"]

--- a/src/content/blog/getting-serial-ports-to-work-on-linux.md
+++ b/src/content/blog/getting-serial-ports-to-work-on-linux.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting serial ports to work on Linux"
-description: ""
+description: "I've recently been \"forced\" to move my desktop from Windows to Linux again. Basically my current desktop \"decided\" it won't support Windows anymore, and…"
 pubDate: "2010-05-09T20:09:11.000Z"
 slug: "getting-serial-ports-to-work-on-linux"
 categories: ["General Techie Stuff","Linux","Technology"]

--- a/src/content/blog/google-chrome-os-and-e-few-more-changes.md
+++ b/src/content/blog/google-chrome-os-and-e-few-more-changes.md
@@ -1,6 +1,6 @@
 ---
 title: "Google Chrome OS and e few more changes"
-description: ""
+description: "Yesterday the Google team posted an entry on all their blogs about a new operating system that is to come. They are going to call it Google Chrome OS."
 pubDate: "2009-07-09T00:00:00.000Z"
 slug: "google-chrome-os-and-e-few-more-changes"
 categories: ["Linux"]

--- a/src/content/blog/how-i-treat-the-links-on-my-blog-with-jquery.md
+++ b/src/content/blog/how-i-treat-the-links-on-my-blog-with-jquery.md
@@ -1,6 +1,6 @@
 ---
 title: "How I treat the links on my blog with JQuery."
-description: ""
+description: "This is a very quick and dirty example of how to treat links on your blog / website using JQuery."
 pubDate: "2008-09-04T00:00:00.000Z"
 slug: "how-i-treat-the-links-on-my-blog-with-jquery"
 categories: ["coldfusion"]

--- a/src/content/blog/how-to-return-tag-contents-with-regular-expressions.md
+++ b/src/content/blog/how-to-return-tag-contents-with-regular-expressions.md
@@ -1,6 +1,6 @@
 ---
 title: "How to return tag contents with regular expressions"
-description: ""
+description: "As most of you already know, I LOVE regular expressions, and think they are great to solve simple and complex tasks involving strings."
 pubDate: "2010-01-27T00:00:00.000Z"
 slug: "how-to-return-tag-contents-with-regular-expressions"
 categories: ["Regular Expressions"]

--- a/src/content/blog/how-to-secure-apache-with-lets-encrypt-and-cloudflare-on-centos.md
+++ b/src/content/blog/how-to-secure-apache-with-lets-encrypt-and-cloudflare-on-centos.md
@@ -1,6 +1,6 @@
 ---
 title: "How to secure Apache with Let's Encrypt and CloudFlare on Centos"
-description: ""
+description: "I took it upon myself to converting a couple of my domains to use Let's Encrypt in order to offer a secure connection to them. If you haven't heard…"
 pubDate: "2016-03-28T17:16:36.000Z"
 slug: "how-to-secure-apache-with-lets-encrypt-and-cloudflare-on-centos"
 categories: ["Technology"]

--- a/src/content/blog/i-am-a-published-author.md
+++ b/src/content/blog/i-am-a-published-author.md
@@ -1,6 +1,6 @@
 ---
 title: "I am a published author"
-description: ""
+description: "A few months ago I was contacted by Packt Publishing about a new project they had in mind and thought I'd be a good fit for."
 pubDate: "2013-04-10T13:50:45.000Z"
 slug: "i-am-a-published-author"
 categories: ["Books"]

--- a/src/content/blog/im-joining-twilio.md
+++ b/src/content/blog/im-joining-twilio.md
@@ -1,6 +1,6 @@
 ---
 title: "I'm joining Twilio"
-description: ""
+description: "So the time has come for me to move on and accept a new challenge. As of the October 20th, I'll be joining Twilio as a Developer Evangelist."
 pubDate: "2014-10-16T14:11:59.000Z"
 slug: "im-joining-twilio"
 categories: ["Technology"]

--- a/src/content/blog/installing-visual-studio-on-a-different-drive.md
+++ b/src/content/blog/installing-visual-studio-on-a-different-drive.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing Visual Studio on a different drive"
-description: ""
+description: "I've got a pro license of Visual Studio 2012, and decided to install it instead of my existing VS 2010 Express install."
 pubDate: "2013-02-13T14:16:53.000Z"
 slug: "installing-visual-studio-on-a-different-drive"
 categories: ["dotnet"]

--- a/src/content/blog/installing-yum-on-centos-5.md
+++ b/src/content/blog/installing-yum-on-centos-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing YUM on CentOS 5"
-description: ""
+description: "This is really for my future reference, but I thought someone would bump into that any time. I'm configuring a new CentOS 5 server and for my surprise…"
 pubDate: "2009-05-15T00:00:00.000Z"
 slug: "installing-yum-on-centos-5"
 categories: ["Linux"]

--- a/src/content/blog/iptables-opening-server-ports-to-specific-ip-addresses.md
+++ b/src/content/blog/iptables-opening-server-ports-to-specific-ip-addresses.md
@@ -1,6 +1,6 @@
 ---
 title: "IPTABLES - Opening server ports to specific IP addresses"
-description: ""
+description: "I have been doing some housekeeping on my VPS, and decided there's a few ports that should only be accessed by certain IP addresses for security purposes."
 pubDate: "2009-09-06T00:00:00.000Z"
 slug: "iptables-opening-server-ports-to-specific-ip-addresses"
 categories: ["Linux"]

--- a/src/content/blog/java-project-skeleton.md
+++ b/src/content/blog/java-project-skeleton.md
@@ -1,6 +1,6 @@
 ---
 title: "Java + Junit + Ant Template Project"
-description: ""
+description: "I could end this post here, and people would have been satisfied to read it. However, I thought I'd add some more context, and maybe throw a little…"
 pubDate: "2013-08-04T01:16:44.000Z"
 slug: "java-project-skeleton"
 categories: ["Java"]

--- a/src/content/blog/javascript-saves-the-day-again.md
+++ b/src/content/blog/javascript-saves-the-day-again.md
@@ -1,6 +1,6 @@
 ---
 title: "Javascript  saves the day again."
-description: ""
+description: "As some of you know, one of my hobbies is electronics with micro controller usage, and I happen to use an electronics forum a lot when I'm losing hair…"
 pubDate: "2008-06-30T00:00:00.000Z"
 slug: "javascript-saves-the-day-again"
 categories: ["Javascript"]

--- a/src/content/blog/jquery-ui-1-6-book-review.md
+++ b/src/content/blog/jquery-ui-1-6-book-review.md
@@ -1,6 +1,6 @@
 ---
 title: "jQuery UI 1.6 - Book Review"
-description: ""
+description: "Book reviewer Marcos Placona | Publisher: Packt. Author(s): Dan Wellman"
 pubDate: "2009-03-11T00:00:00.000Z"
 slug: "jquery-ui-1-6-book-review"
 categories: ["books"]

--- a/src/content/blog/jquery-ui-1-7-1-released.md
+++ b/src/content/blog/jquery-ui-1-7-1-released.md
@@ -1,6 +1,6 @@
 ---
 title: "jQuery UI 1.7.1 Released"
-description: ""
+description: "The jQuery UI team have done it again. This Friday is only a point release to the jQuery UI 1.7 released last week but with some great improvements."
 pubDate: "2009-03-20T00:00:00.000Z"
 slug: "jquery-ui-1-7-1-released"
 categories: ["Javascript"]
@@ -22,7 +22,7 @@ The jQuery UI team have done it again. This Friday is only a point release to th
 
   * Fixed: Selectable: option appendTo is ignored, helper always appends to body (<a title="http://dev.jqueryui.com/ticket/4341" href="http://bugs.jqueryui.com/ticket/4341" target="_blank">4341</a>) 
 
-# Widgets 
+## Widgets
 
 ### Accordion 
 

--- a/src/content/blog/jquery-ui-1-7-released.md
+++ b/src/content/blog/jquery-ui-1-7-released.md
@@ -1,6 +1,6 @@
 ---
 title: "jQuery UI 1.7 Released"
-description: ""
+description: "The jQuery UI team has marked a major milestone for the UI. Today they released version 1.7 with some nice updates, and also put their own dedicated…"
 pubDate: "2009-03-06T00:00:00.000Z"
 slug: "jquery-ui-1-7-released"
 categories: ["Javascript"]

--- a/src/content/blog/jquery-ui-updates.md
+++ b/src/content/blog/jquery-ui-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "jQuery UI Updates"
-description: ""
+description: "The jQuery UI team has just started a weekly series on what's happening with jQuery UI."
 pubDate: "2009-03-13T00:00:00.000Z"
 slug: "jquery-ui-updates"
 categories: ["Javascript"]

--- a/src/content/blog/learning-jquery-1-3-book-review.md
+++ b/src/content/blog/learning-jquery-1-3-book-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Learning jQuery 1.3 - Book Review"
-description: ""
+description: "Book reviewer Marcos Placona | Publisher: Packt. Author(s): Jonathan Chaffer, Karl Swedberg"
 pubDate: "2009-04-25T00:00:00.000Z"
 slug: "learning-jquery-1-3-book-review"
 categories: ["Books"]

--- a/src/content/blog/learning-jquery-book-review.md
+++ b/src/content/blog/learning-jquery-book-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Learning JQuery - Book Review"
-description: ""
+description: "Book reviewer Marcos Placona | Publisher: Packt. Author(s): Jonathan Chaffer and Karl Swedberg"
 pubDate: "2008-09-05T00:00:00.000Z"
 slug: "learning-jquery-book-review"
 categories: ["books"]

--- a/src/content/blog/making-it-snow-with-dart.md
+++ b/src/content/blog/making-it-snow-with-dart.md
@@ -1,6 +1,6 @@
 ---
 title: "Making it snow with Dart"
-description: ""
+description: "After my last example showing you how to create a matrix effect with Dart, I thought it would be cool, to follow up with another example that used the…"
 pubDate: "2014-03-30T20:57:06.000Z"
 slug: "making-it-snow-with-dart"
 categories: ["Dart"]

--- a/src/content/blog/making-your-jmeter-tests-timeless.md
+++ b/src/content/blog/making-your-jmeter-tests-timeless.md
@@ -1,6 +1,6 @@
 ---
 title: "Making your JMeter tests timeless."
-description: ""
+description: "At work, we use Apache JMeter for load testing applications or API's we build."
 pubDate: "2012-08-31T15:45:16.000Z"
 slug: "making-your-jmeter-tests-timeless"
 categories: ["Technology"]

--- a/src/content/blog/managing-your-dotfiles-the-right-way.md
+++ b/src/content/blog/managing-your-dotfiles-the-right-way.md
@@ -1,6 +1,6 @@
 ---
 title: "Managing your dotfiles the right way"
-description: ""
+description: "It's no secret that on the UNIX world, dotfiles play a very important part when it comes to making your terminal look good. Be it on Linux, be it on a…"
 pubDate: "2013-04-01T21:12:09.000Z"
 slug: "managing-your-dotfiles-the-right-way"
 categories: ["Technology"]

--- a/src/content/blog/matrix-effect-with-dart.md
+++ b/src/content/blog/matrix-effect-with-dart.md
@@ -1,6 +1,6 @@
 ---
 title: "Matrix effect with Dart"
-description: ""
+description: "After my last post on Dart, I decided that I wanted to write something a bit more complex using the language. I had a lot of good feedback on it, but…"
 pubDate: "2014-03-24T13:53:51.000Z"
 slug: "matrix-effect-with-dart"
 categories: ["Dart"]

--- a/src/content/blog/migrating-mango-blog-to-wordpress.md
+++ b/src/content/blog/migrating-mango-blog-to-wordpress.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating Mango Blog to WordPress"
-description: ""
+description: "As previously promised , today I'll be publishing my migration scrips from Mango Blog to WordPress ."
 pubDate: "2010-05-03T11:00:48.000Z"
 slug: "migrating-mango-blog-to-wordpress"
 categories: ["coldfusion"]

--- a/src/content/blog/mobile-tablet-development-my-saga-1.md
+++ b/src/content/blog/mobile-tablet-development-my-saga-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile and Tablet development - My Saga I"
-description: ""
+description: "So I believe by my last posts here you may have guessed I've been doing lots of mobile development in the last few months."
 pubDate: "2011-10-27T08:27:00.000Z"
 slug: "mobile-tablet-development-my-saga-1"
 categories: ["Mobile Development"]

--- a/src/content/blog/moving-svn-folders.md
+++ b/src/content/blog/moving-svn-folders.md
@@ -1,6 +1,6 @@
 ---
 title: "Moving SVN Folders"
-description: ""
+description: "I recently had to move an entire folder on SVN from a place to another. When you think \"folders\", you simply imagine that would be an easy drag & drop task."
 pubDate: "2010-06-22T11:32:42.000Z"
 slug: "moving-svn-folders"
 categories: ["Technology"]

--- a/src/content/blog/mozilla-firefox-3-alpha-1-ready-to-be-downloaded.md
+++ b/src/content/blog/mozilla-firefox-3-alpha-1-ready-to-be-downloaded.md
@@ -1,6 +1,6 @@
 ---
 title: "Mozilla Firefox 3 Alpha 1 ready to be downloaded"
-description: ""
+description: "Yes, it seems that Mozilla just released the new version of Firefox codenamed Gran Paradiso."
 pubDate: "2006-12-11T00:00:00.000Z"
 slug: "mozilla-firefox-3-alpha-1-ready-to-be-downloaded"
 categories: ["Misc"]

--- a/src/content/blog/multi-line-c-sharp-strings.md
+++ b/src/content/blog/multi-line-c-sharp-strings.md
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Line C# Strings"
-description: ""
+description: "I’ve seen this question being asked on StackOverflow so many times I event thought about writing a bot to automatically reply to it."
 pubDate: "2016-02-22T11:28:01.000Z"
 slug: "multi-line-c-sharp-strings"
 categories: ["dotnet"]

--- a/src/content/blog/my-nodejs-app-development-experience.md
+++ b/src/content/blog/my-nodejs-app-development-experience.md
@@ -1,6 +1,6 @@
 ---
 title: "My NodeJS app development experience"
-description: ""
+description: "So, I decided to take a punt at writing a NodeJS application. Not a big application, or anything that would get me slashdoted, but an application that…"
 pubDate: "2013-04-18T18:27:57.000Z"
 slug: "my-nodejs-app-development-experience"
 categories: ["Javascript"]

--- a/src/content/blog/my-top-favourite-twitter-tools.md
+++ b/src/content/blog/my-top-favourite-twitter-tools.md
@@ -1,6 +1,6 @@
 ---
 title: "My top favourite twitter tools"
-description: ""
+description: "UPDATEI'm constantly finding new tools that help me to use my twitter account in a better way. Some of the tools are really great, but I can't be…"
 pubDate: "2009-03-10T00:00:00.000Z"
 slug: "my-top-favourite-twitter-tools"
 categories: ["Technology"]

--- a/src/content/blog/mysql-killed-my-hamster.md
+++ b/src/content/blog/mysql-killed-my-hamster.md
@@ -1,6 +1,6 @@
 ---
 title: "mySQL killed my hamster"
-description: ""
+description: "I've run some updates on my server today, and got prompted to upgrade mySQL."
 pubDate: "2010-09-21T21:56:51.000Z"
 slug: "mysql-killed-my-hamster"
 categories: ["Technology"]

--- a/src/content/blog/new-teamcity-agents-the-right-way.md
+++ b/src/content/blog/new-teamcity-agents-the-right-way.md
@@ -1,6 +1,6 @@
 ---
 title: "New TeamCity agents the right way"
-description: ""
+description: "At work, I'm gradually moving our CI server from Hudson to TeamCity."
 pubDate: "2014-03-03T21:45:35.000Z"
 slug: "new-teamcity-agents-the-right-way"
 categories: ["dotnet"]

--- a/src/content/blog/nifty-jquery-tricks-ajax-events.md
+++ b/src/content/blog/nifty-jquery-tricks-ajax-events.md
@@ -1,6 +1,6 @@
 ---
 title: "Nifty jQuery tricks - Ajax Events"
-description: ""
+description: "As previously mentioned on my other post, I'm working on improving usability and user experience within one of our applications."
 pubDate: "2010-10-04T11:00:37.000Z"
 slug: "nifty-jquery-tricks-ajax-events"
 categories: ["JavaScript"]

--- a/src/content/blog/nifty-jquery-tricks-avoid-cache.md
+++ b/src/content/blog/nifty-jquery-tricks-avoid-cache.md
@@ -1,6 +1,6 @@
 ---
 title: "Nifty jQuery tricks - Avoid Cache"
-description: ""
+description: "I found this two function yesterday while working on one of our applications."
 pubDate: "2010-10-02T23:19:19.000Z"
 slug: "nifty-jquery-tricks-avoid-cache"
 categories: ["JavaScript"]

--- a/src/content/blog/picasso-same-url-but-different-content.md
+++ b/src/content/blog/picasso-same-url-but-different-content.md
@@ -1,6 +1,6 @@
 ---
 title: "Picasso - Same URL but different content"
-description: ""
+description: "I love using Square's Picasso library whenever I need to load images into my Android applications. It lets me load images from the internet into…"
 pubDate: "2016-09-17T23:26:34.000Z"
 slug: "picasso-same-url-but-different-content"
 categories: ["Android"]

--- a/src/content/blog/quick-and-dirty-jquery-drag-drop.md
+++ b/src/content/blog/quick-and-dirty-jquery-drag-drop.md
@@ -1,6 +1,6 @@
 ---
 title: "Quick and dirty jQuery drag & drop"
-description: ""
+description: "I feel kinda bad to be calling this dirty, but mind you, I'm only using dirty as an expression, as it's freaking sweet."
 pubDate: "2009-03-01T00:00:00.000Z"
 slug: "quick-and-dirty-jquery-drag-drop"
 categories: ["Javascript"]

--- a/src/content/blog/quick-tip-on-flash-builder-and-application-internationalization.md
+++ b/src/content/blog/quick-tip-on-flash-builder-and-application-internationalization.md
@@ -1,6 +1,6 @@
 ---
 title: "Quick tip on Flash Builder and application internationalization"
-description: ""
+description: "I'm building a new Blackberry Playbook app, and when starting to work with internationalization, I got stuck with a bug that wouldn't go away. I'm…"
 pubDate: "2011-06-01T22:58:10.000Z"
 slug: "quick-tip-on-flash-builder-and-application-internationalization"
 categories: ["Adobe"]

--- a/src/content/blog/recursively-delete-folders-with-python.md
+++ b/src/content/blog/recursively-delete-folders-with-python.md
@@ -1,6 +1,6 @@
 ---
 title: "Recursively delete folders with Python"
-description: ""
+description: "At work we've been doing some deploy optimization, and the need of automatically deleting (recursively) specific folders came up."
 pubDate: "2009-08-07T00:00:00.000Z"
 slug: "recursively-delete-folders-with-python"
 categories: ["Technology"]

--- a/src/content/blog/ripping-mp3-s-on-ubuntu.md
+++ b/src/content/blog/ripping-mp3-s-on-ubuntu.md
@@ -1,6 +1,6 @@
 ---
 title: "Ripping MP3's on Ubuntu"
-description: ""
+description: "I've never tested doing this, but will give it a try later"
 pubDate: "2006-12-12T00:00:00.000Z"
 slug: "ripping-mp3-s-on-ubuntu"
 categories: ["Linux"]

--- a/src/content/blog/simple-tcp-server-with-dart-setup.md
+++ b/src/content/blog/simple-tcp-server-with-dart-setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Simple HTTP server with Dart - Setup"
-description: ""
+description: "In this article, I will demonstrate how easy it is to create a simple TCP HTTP server with Dart."
 pubDate: "2014-04-01T22:15:22.000Z"
 slug: "simple-tcp-server-with-dart-setup"
 categories: ["Dart"]

--- a/src/content/blog/so-what-else-do-you-need-then.md
+++ b/src/content/blog/so-what-else-do-you-need-then.md
@@ -1,6 +1,6 @@
 ---
 title: "So what else do you need then?"
-description: ""
+description: "Last week it came to my attention that ColdFusion is being used by 75 of the Fortune 100 companies . Then, I was also informed that ColdFusion was…"
 pubDate: "2009-03-23T00:00:00.000Z"
 slug: "so-what-else-do-you-need-then"
 categories: ["coldfusion"]

--- a/src/content/blog/speed-up-yor-website-part-1.md
+++ b/src/content/blog/speed-up-yor-website-part-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Speed up yor website - Part 1"
-description: ""
+description: "Assets such as stylesheets, images and videos are often the major hit taken by a webserver when a webpage is loaded. I'm often trying to improve my page…"
 pubDate: "2009-07-21T00:00:00.000Z"
 slug: "speed-up-yor-website-part-1"
 categories: ["Technology"]

--- a/src/content/blog/speed-up-yor-website-part-2-the-free-cdn.md
+++ b/src/content/blog/speed-up-yor-website-part-2-the-free-cdn.md
@@ -1,6 +1,6 @@
 ---
 title: "Speed up yor website - Part 2 - The Free CDN"
-description: ""
+description: "To continue with our series of website optimization tricks, I'll talk a little bit more about Content Delivery Network (CDN) , and will talk you though…"
 pubDate: "2009-07-23T00:00:00.000Z"
 slug: "speed-up-yor-website-part-2-the-free-cdn"
 categories: ["Technology"]

--- a/src/content/blog/sqlite-databases-and-mobile-applications-a-caveat.md
+++ b/src/content/blog/sqlite-databases-and-mobile-applications-a-caveat.md
@@ -1,6 +1,6 @@
 ---
 title: "SQLite databases and mobile applications - A caveat"
-description: ""
+description: "As some of you might have noticed, I have been building some mobile applications lately on my spare time specifically for the Blackberry Playbook . They…"
 pubDate: "2011-06-06T14:18:41.000Z"
 slug: "sqlite-databases-and-mobile-applications-a-caveat"
 categories: ["Adobe"]

--- a/src/content/blog/sticky-javascript-persistence.md
+++ b/src/content/blog/sticky-javascript-persistence.md
@@ -1,6 +1,6 @@
 ---
 title: "Sticky JavaScript Persistence"
-description: ""
+description: "On my last blog post I explained how to create a drag and drop using cloning, so you can can drag & drop multiple objects"
 pubDate: "2009-08-10T00:00:00.000Z"
 slug: "sticky-javascript-persistence"
 categories: ["Javascript"]

--- a/src/content/blog/sync-your-outlook-or-google-calendar-with-the-iphone.md
+++ b/src/content/blog/sync-your-outlook-or-google-calendar-with-the-iphone.md
@@ -1,6 +1,6 @@
 ---
 title: "Sync your iPhone with Outlook (or Google) Calendar"
-description: ""
+description: "We all know how painful it is to keep up to date with our meeting and"
 pubDate: "2009-04-29T00:00:00.000Z"
 slug: "sync-your-outlook-or-google-calendar-with-the-iphone"
 categories: ["Technology"]

--- a/src/content/blog/the-day-finally-came.md
+++ b/src/content/blog/the-day-finally-came.md
@@ -1,6 +1,6 @@
 ---
 title: "The day finally came!"
-description: ""
+description: "And of course I was out of the country and then too busy to even read anything about it."
 pubDate: "2009-04-16T00:00:00.000Z"
 slug: "the-day-finally-came"
 categories: ["coldfusion"]

--- a/src/content/blog/things-you-may-not-know-about-jquery.md
+++ b/src/content/blog/things-you-may-not-know-about-jquery.md
@@ -1,6 +1,6 @@
 ---
 title: "Things you may not know about jQuery"
-description: ""
+description: "I just came across this very interesting list of things you can do with jQuery ."
 pubDate: "2009-02-19T00:00:00.000Z"
 slug: "things-you-may-not-know-about-jquery"
 categories: ["javascript"]

--- a/src/content/blog/tip-of-the-day-regular-expression-generator.md
+++ b/src/content/blog/tip-of-the-day-regular-expression-generator.md
@@ -1,6 +1,6 @@
 ---
 title: "Tip of the day: Regular Expression Generator"
-description: ""
+description: "I have just came across this very nice service which promises to write Regular Expressions for you."
 pubDate: "2009-03-05T00:00:00.000Z"
 slug: "tip-of-the-day-regular-expression-generator"
 categories: ["technology"]

--- a/src/content/blog/tokenizing-a-string-with-java.md
+++ b/src/content/blog/tokenizing-a-string-with-java.md
@@ -1,6 +1,6 @@
 ---
 title: "Tokenizing a string with Java."
-description: ""
+description: "As everybody knows, this Blog should show my studies integrating CFML with other technologies. Today I was playing with the Java class arrayList() and…"
 pubDate: "2005-09-21T00:00:00.000Z"
 slug: "tokenizing-a-string-with-java"
 categories: ["coldfusion","blog"]

--- a/src/content/blog/ubuntu-experience.md
+++ b/src/content/blog/ubuntu-experience.md
@@ -1,6 +1,6 @@
 ---
 title: "Ubuntu Experience"
-description: ""
+description: "Following the last post about network problems and dodgy Firewalls. This time I decided to install Ubuntu on my laptop. I have to be honest saying that…"
 pubDate: "2006-12-07T00:00:00.000Z"
 slug: "ubuntu-experience"
 categories: ["Linux"]

--- a/src/content/blog/uk-top-40-albums-singles-json.md
+++ b/src/content/blog/uk-top-40-albums-singles-json.md
@@ -1,6 +1,6 @@
 ---
 title: "UK Top 40 albums & singles JSON"
-description: ""
+description: "So I had this idea for a little application and wanted to get the UK's Top40 singles to use in it. I started by writing something that would scrape…"
 pubDate: "2013-06-23T22:46:10.000Z"
 slug: "uk-top-40-albums-singles-json"
 categories: ["Technology"]

--- a/src/content/blog/updating-java-on-centos.md
+++ b/src/content/blog/updating-java-on-centos.md
@@ -1,6 +1,6 @@
 ---
 title: "Updating Java on Centos"
-description: ""
+description: "I'm only writing this blog post because I usually try to keep my VPS up to date, and usually one of the things I have to do to accomplish such thing is…"
 pubDate: "2009-09-02T00:00:00.000Z"
 slug: "updating-java-on-centos"
 categories: ["Linux"]

--- a/src/content/blog/upgrading-castle-from-2-1-to-2-5.md
+++ b/src/content/blog/upgrading-castle-from-2-1-to-2-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading Castle from 2.1 to 2.5"
-description: ""
+description: "I was recently working on a .Net project that uses Castle as it's IoC Container. At some point I realized it would be beneficial to have Castle running…"
 pubDate: "2012-07-23T11:16:46.000Z"
 slug: "upgrading-castle-from-2-1-to-2-5"
 categories: ["dotnet"]

--- a/src/content/blog/varnish-with-apache-and-wordpress-on-centos.md
+++ b/src/content/blog/varnish-with-apache-and-wordpress-on-centos.md
@@ -1,6 +1,6 @@
 ---
 title: "Varnish with Apache and WordPress on Centos"
-description: ""
+description: "Varnish is wicked! It works on your webserver as a reverse proxy to cache HTTP requests. According to their website:"
 pubDate: "2014-04-23T21:45:29.000Z"
 slug: "varnish-with-apache-and-wordpress-on-centos"
 categories: ["technology"]

--- a/src/content/blog/want-a-free-copy-of-my-new-book.md
+++ b/src/content/blog/want-a-free-copy-of-my-new-book.md
@@ -1,6 +1,6 @@
 ---
 title: "Want a free copy of my new book?"
-description: ""
+description: "No catches here, all you need to do to get a free e-copy of my new book"
 pubDate: "2013-05-17T08:24:09.000Z"
 slug: "want-a-free-copy-of-my-new-book"
 categories: ["Books"]

--- a/src/content/blog/what-breaks-wp-super-cache.md
+++ b/src/content/blog/what-breaks-wp-super-cache.md
@@ -1,6 +1,6 @@
 ---
 title: "What breaks WP Super Cache"
-description: ""
+description: "Disclaimer: This blog post is not meant to be timeless, meaning it will lose its relevancy as soon as the stuff I'll mention below gets updated. I will…"
 pubDate: "2012-08-29T08:09:52.000Z"
 slug: "what-breaks-wp-super-cache"
 categories: ["Technology"]

--- a/src/content/blog/what-s-jrun-s-name.md
+++ b/src/content/blog/what-s-jrun-s-name.md
@@ -1,6 +1,6 @@
 ---
 title: "What's Jrun's name?"
-description: ""
+description: "Just found it on my old ColdFusion installation and thought it might be useful for someone in a multiple Jrun installations environment."
 pubDate: "2006-12-05T00:00:00.000Z"
 slug: "what-s-jrun-s-name"
 categories: ["coldfusion"]

--- a/src/content/blog/windows-mobile-on-the-iphone-hoax.md
+++ b/src/content/blog/windows-mobile-on-the-iphone-hoax.md
@@ -1,6 +1,6 @@
 ---
 title: "Windows Mobile on the iPhone? Hoax?"
-description: ""
+description: "I've just seen this video and thought I'd share it with my few readers. It appears that a Norwegian lad found a way to boot Windows Mobile OS on the…"
 pubDate: "2009-03-09T00:00:00.000Z"
 slug: "windows-mobile-on-the-iphone-hoax"
 categories: ["Technology"]

--- a/src/content/blog/wireless-now-working-on-ubuntu.md
+++ b/src/content/blog/wireless-now-working-on-ubuntu.md
@@ -1,6 +1,6 @@
 ---
 title: "Wireless now working on Ubuntu"
-description: ""
+description: "As previously said I was having some kind of troubles with my wireless connection on Ubuntu."
 pubDate: "2006-12-08T00:00:00.000Z"
 slug: "wireless-now-working-on-ubuntu"
 categories: ["Linux"]

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -70,7 +70,7 @@ if (props.kind === 'post') {
     </nav>
   </BaseLayout>
 ) : (
-  <BaseLayout title={`${post!.data.title} | Marcos Placona`} description={post!.data.description} image={post!.data.image} canonicalPath={`/${post!.data.slug}/`}>
+  <BaseLayout title={`${post!.data.title} | Marcos Placona`} description={post!.data.description || `Read Marcos Placona’s article: ${post!.data.title}.`} image={post!.data.image} canonicalPath={`/${post!.data.slug}/`}>
     <article class="post">
       <header class="post-header">
         <p class="eyebrow">{post!.data.pubDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }).toUpperCase()}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,13 +11,13 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 <BaseLayout>
   <section class="hero">
     <p class="eyebrow">Developer relations · software · independent products</p>
-    <h1>Programming, technology and musings.</h1>
-    <p>I’m Marcos Placona. I write about building things for developers and the occasional useful side quest.</p>
+    <h1>Developer relations, software and useful side quests.</h1>
+    <p>I’m Marcos Placona. I write about building things for developers, independent products and the occasional useful side quest.</p>
   </section>
   <section class="content-section" aria-labelledby="latest-writing">
     <div class="section-heading">
       <p class="eyebrow">Latest writing</p>
-      <h2 id="latest-writing">The archive, without the Ruby tax.</h2>
+      <h2 id="latest-writing">Latest writing.</h2>
     </div>
     <div class="post-list">
       {posts.map((post) => <PostCard post={post} />)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,10 @@
 :root {
-  --ink: #151515;
-  --muted: #65615d;
+  --ink: #181717;
+  --muted: #68635d;
   --paper: #fffdf9;
-  --sand: #f2ede5;
+  --sand: #f4efe7;
   --accent: #b83935;
-  --line: #dfd8ce;
+  --line: #ded7cd;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--ink);
   background: var(--paper);
@@ -12,76 +12,88 @@
 
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
-body { margin: 0; line-height: 1.6; }
-a { color: inherit; text-underline-offset: .2em; }
+body { margin: 0; min-width: 320px; line-height: 1.6; }
+a { color: inherit; text-decoration-thickness: 1px; text-underline-offset: .2em; }
 a:hover { color: var(--accent); }
-img { max-width: 100%; height: auto; }
+img { display: block; max-width: 100%; height: auto; }
 
 .skip-link { position: absolute; left: -9999px; top: 0; background: var(--ink); color: white; padding: .7rem 1rem; z-index: 10; }
 .skip-link:focus { left: 1rem; top: 1rem; }
-.site-header, .site-footer { max-width: 1140px; margin: auto; padding: 1.25rem 1.5rem; }
-.site-header { display: flex; justify-content: space-between; align-items: center; gap: 1.5rem; border-bottom: 1px solid var(--line); }
+.site-header, .site-footer { width: min(100% - 3rem, 1140px); margin: auto; }
+.site-header { display: flex; justify-content: space-between; align-items: center; gap: 1.5rem; min-height: 72px; border-bottom: 1px solid var(--line); }
 .brand { display: inline-flex; align-items: center; gap: .6rem; text-decoration: none; font-weight: 800; letter-spacing: -.03em; }
 .brand img { width: 32px; height: 32px; object-fit: contain; }
-nav { display: flex; flex-wrap: wrap; gap: 1rem; font-size: .95rem; }
+nav { display: flex; flex-wrap: wrap; gap: 1.1rem; font-size: .95rem; }
 nav a { text-decoration: none; }
-.site-footer { border-top: 1px solid var(--line); color: var(--muted); font-size: .9rem; }
+.site-footer { margin-top: 4.5rem; padding: 1.25rem 0 2.5rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .9rem; }
 .site-footer p { margin: .2rem 0; }
 
-.hero, .content-section, .article-shell, .app-page { max-width: 920px; margin: auto; padding: 4.5rem 1.5rem; }
-.hero { padding-bottom: 2rem; }
+.hero, .content-section, .app-page, .page-intro, .post-list, .pagination { width: min(100% - 3rem, 920px); margin-left: auto; margin-right: auto; }
+.hero { padding: clamp(4rem, 9vw, 8rem) 0 clamp(3rem, 6vw, 5rem); }
 .compact-hero { padding-bottom: 1rem; }
-.eyebrow { color: var(--accent); font-size: .78rem; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.eyebrow { margin: 0 0 .75rem; color: var(--accent); font-size: .75rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
 h1, h2, h3 { line-height: 1.08; letter-spacing: -.045em; }
-h1 { max-width: 850px; font-size: clamp(2.6rem, 7vw, 5.7rem); margin: .3rem 0 1.2rem; }
-h2 { font-size: clamp(1.6rem, 3vw, 2.5rem); }
-.hero > p:not(.eyebrow), .lede { max-width: 700px; font-size: clamp(1.15rem, 2vw, 1.45rem); color: #3e3b38; }
-.content-section { padding-top: 2rem; padding-bottom: 3.5rem; }
-.section-heading { margin-bottom: 1.5rem; }
+h1 { max-width: 15ch; margin: 0 0 1.25rem; font-size: clamp(2.75rem, 6vw, 5.5rem); }
+h2 { font-size: clamp(1.6rem, 3vw, 2.45rem); }
+.hero > p:not(.eyebrow), .lede { max-width: 39rem; margin: 0; font-size: clamp(1.15rem, 2vw, 1.4rem); line-height: 1.5; color: #49443e; }
+.content-section { padding: 1.5rem 0 3.5rem; }
+.section-heading { display: grid; gap: .2rem; margin-bottom: 1.5rem; }
+.section-heading h2 { margin: 0; }
 .post-list { border-top: 1px solid var(--line); }
-.post-card { padding: 1.7rem 0; border-bottom: 1px solid var(--line); }
-.post-card h2 { margin: .15rem 0 .4rem; }
+.post-card { padding: 1.75rem 0; border-bottom: 1px solid var(--line); }
+.post-card h2 { max-width: 24ch; margin: .15rem 0 .45rem; }
 .post-card h2 a { text-decoration: none; }
-.post-card p { max-width: 720px; margin: .3rem 0 .8rem; color: var(--muted); }
+.post-card p { max-width: 45rem; margin: .3rem 0 .85rem; color: var(--muted); }
 .text-link { font-weight: 700; }
 .button, .button-secondary { display: inline-block; padding: .75rem 1rem; border: 1px solid var(--ink); font-weight: 700; text-decoration: none; }
 .button { background: var(--ink); color: white; }
 .button-secondary { border-color: var(--accent); color: var(--accent); }
 .button:hover, .button-secondary:hover { background: var(--accent); border-color: var(--accent); color: white; }
 
-.article-shell { max-width: 800px; }
-.article-header { margin-bottom: 2.5rem; }
-.article-header h1 { font-size: clamp(2.4rem, 6vw, 4.6rem); }
-.taxonomy { color: var(--muted); font-size: .92rem; }
-.article-image { width: 100%; max-height: 520px; object-fit: cover; margin: 1rem 0 2.2rem; border-radius: .2rem; }
-.prose { font-family: Georgia, "Times New Roman", serif; font-size: 1.12rem; }
-.prose h2, .prose h3 { margin-top: 2.4rem; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
-.prose pre { overflow: auto; padding: 1rem; background: #171717; color: #f9f9f9; border-radius: .25rem; font-size: .85rem; }
-.prose code { font-size: .88em; }
+.post { width: min(100% - 3rem, 760px); margin: 0 auto; padding: clamp(3.25rem, 7vw, 6.5rem) 0 1rem; }
+.post-header { max-width: 760px; margin-bottom: 3.25rem; }
+.post-header h1 { max-width: 13ch; margin-bottom: 1.35rem; font-size: clamp(2.6rem, 5.2vw, 4.75rem); }
+.post-meta { margin: 1.4rem 0 0; color: var(--muted); font-size: .92rem; }
+.prose { max-width: 700px; font-family: Georgia, "Times New Roman", serif; font-size: clamp(1.05rem, 1.5vw, 1.18rem); line-height: 1.78; }
+.prose > :first-child { margin-top: 0; }
+.prose h2, .prose h3, .prose h4 { font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+.prose h2 { margin: 3.25rem 0 1rem; font-size: clamp(1.7rem, 3vw, 2.3rem); }
+.prose h3 { margin: 2.5rem 0 .75rem; font-size: clamp(1.3rem, 2.3vw, 1.7rem); }
+.prose h4 { margin: 2rem 0 .65rem; font-size: 1.15rem; }
+.prose p, .prose ul, .prose ol { margin: 0 0 1.45rem; }
+.prose li + li { margin-top: .45rem; }
+.prose blockquote { margin: 2rem 0; padding-left: 1.25rem; border-left: 3px solid var(--accent); color: #4e4943; }
+.prose pre { overflow: auto; margin: 1.75rem 0; padding: 1rem 1.2rem; background: #1d1b19; color: #f9f7f3; border-radius: .25rem; font-size: .85rem; line-height: 1.55; }
+.prose :not(pre) > code { padding: .12em .32em; background: var(--sand); font-size: .86em; }
 .prose img, .prose iframe { max-width: 100%; border: 0; }
+.prose img { margin: 2rem 0; }
 .prose iframe { aspect-ratio: 16 / 9; width: 100%; }
-.article-pagination { display: flex; justify-content: space-between; gap: 1rem; margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--line); font-weight: 700; }
-.article-pagination a { width: 48%; }
-.article-pagination a:last-child { text-align: right; }
+.article-nav { display: flex; justify-content: space-between; gap: 1.5rem; margin-top: 4.5rem; padding-top: 1.5rem; border-top: 1px solid var(--line); font-size: .95rem; font-weight: 700; }
+.article-nav a { max-width: 48%; }
+.article-nav a:last-child { text-align: right; }
 
 .app-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
 .app-card, .callout { padding: 1.5rem; background: var(--sand); }
 .app-card h2 { margin: .3rem 0; }
 .app-tagline { font-size: 1.25rem; font-weight: 700; }
 .split-section { display: grid; grid-template-columns: 1fr 1.3fr; gap: 4rem; border-top: 1px solid var(--line); }
-.callout { margin: 0 1.5rem 4.5rem; max-width: 920px; }
-.empty-state { max-width: 620px; margin: auto; padding: 8rem 1.5rem; text-align: center; }
+.callout { width: min(100% - 3rem, 920px); margin: 0 auto 4.5rem; }
+.empty-state { width: min(100% - 3rem, 620px); margin: auto; padding: 8rem 0; text-align: center; }
 .search-label { display: block; font-weight: 700; margin-bottom: .5rem; }
 .search-input { width: 100%; padding: 1rem; border: 1px solid var(--ink); background: white; font: inherit; }
 .search-results { padding: 0; list-style: none; }
 .search-results li { padding: 1.2rem 0; border-bottom: 1px solid var(--line); }
 .search-results a { font-weight: 800; font-size: 1.2rem; }
 .search-results p { margin: .3rem 0 0; color: var(--muted); }
+.pagination { display: flex; justify-content: space-between; gap: 1rem; padding-top: 2rem; }
 
 @media (max-width: 680px) {
-  .site-header { align-items: flex-start; flex-direction: column; }
-  .hero, .content-section, .article-shell, .app-page { padding-top: 3rem; }
+  .site-header { align-items: flex-start; flex-direction: column; justify-content: center; padding: 1rem 0; }
+  nav { gap: .8rem 1rem; font-size: .9rem; }
+  .hero { padding-top: 3.5rem; }
+  .post { padding-top: 3rem; }
+  .post-header { margin-bottom: 2.5rem; }
   .split-section { grid-template-columns: 1fr; gap: 1rem; }
-  .article-pagination { flex-direction: column; }
-  .article-pagination a, .article-pagination a:last-child { width: auto; text-align: left; }
+  .article-nav { flex-direction: column; }
+  .article-nav a, .article-nav a:last-child { max-width: none; text-align: left; }
 }


### PR DESCRIPTION
## Why this is urgent

The Astro migration successfully preserved the URLs, but the production crawl found two genuine SEO regressions and the article layout was broken:

- `/robots.txt` returned a 404.
- 90 of 115 sitemap URLs had an empty meta description.
- Three articles rendered more than one H1 because legacy Markdown headings were not normalised.
- Article pages used `post` / `post-header` classes that had no layout rules, causing the full-width, enormous-title page shown in the report.

## Changes

- Adds an explicit `robots.txt` with the canonical sitemap declaration.
- Derives factual meta descriptions from each article's existing first substantive paragraph; no invented claims.
- Makes descriptions required by the content schema.
- Normalises migrated Markdown so legacy body H1s become H2s and removes a leading duplicate heading when it repeats the article title.
- Repairs the article column, typography, prose rhythm, code, navigation and responsive layout.
- Tightens the homepage hierarchy and removes the pointless "Ruby tax" copy.

## Verification

- `npm ci`
- `npm run migrate:posts`
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — 116 static pages
- Static audit: all 115 HTML pages have exactly one H1, a non-empty description, the expected canonical, and no missing `/images` or `/_astro` assets.
- Production crawl before this change: all 115 sitemap URLs returned 200 with correct canonicals; no broken image URLs. The open defects above are addressed here.
- Browser-inspected repaired homepage and the reported article at desktop width: centred 760px reading column, no overflow, no duplicate lead heading.
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
