### PR TITLE
ci: deploy a preview site for every pull request

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,13 +2,14 @@ name: Build and deploy Astro site to GitHub Pages
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pages: write
+  id-token: write
 
 concurrency:
   group: pages
@@ -27,20 +28,49 @@ jobs:
       - run: npm run check
       - run: npm run build
       - if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: site
           path: ./dist
 
-  deploy:
+  # Publishes the site to the gh-pages branch root. PR previews live in
+  # pr-* directories on the same branch, so they are excluded from the clean.
+  publish-branch:
     if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: ./dist
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist
+          clean: true
+          clean-exclude: |
+            pr-*
+
+  # The original GitHub Actions deployment path. Keep it running until the
+  # Pages source is switched to the gh-pages branch, then set the repository
+  # variable PAGES_SOURCE to "branch" to turn it off. See docs/previews.md.
+  deploy-workflow-source:
+    if: github.event_name != 'pull_request' && vars.PAGES_SOURCE != 'branch'
+    needs: build
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: ./dist
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,30 @@
+name: Clean up PR preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-pages-${{ github.ref }}
+
+jobs:
+  clean-up:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove the preview directory
+        run: |
+          rm -rf "pr-${{ github.event.number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Clean preview for pr-${{ github.event.number }}"
+            git push
+          fi

--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -1,0 +1,63 @@
+name: Deploy PR preview
+
+on:
+  pull_request:
+
+# contents: write publishes the preview to the gh-pages branch.
+# pull-requests: write posts the preview URL back onto the PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run check
+      - run: npm run build
+
+      # The preview is served from a subdirectory, but Astro emits root-absolute
+      # paths (/_astro/..., /images/..., /about/). Left alone, a preview would
+      # load production's stylesheet and navigate to production. Rewrite them to
+      # the preview prefix. Protocol-relative (//) and absolute (https://) URLs
+      # are untouched, so canonical and og:url keep pointing at the real site.
+      - name: Rebase asset and link paths onto the preview prefix
+        env:
+          PREFIX: /pr-${{ github.event.number }}
+        run: |
+          find dist -name '*.html' -print0 | xargs -0 sed -i \
+            -e "s|href=\"/\([^/]\)|href=\"${PREFIX}/\1|g" \
+            -e "s|src=\"/\([^/]\)|src=\"${PREFIX}/\1|g" \
+            -e "s|href=\"/\"|href=\"${PREFIX}/\"|g" \
+            -e "s|srcset=\"/\([^/]\)|srcset=\"${PREFIX}/\1|g"
+
+      # Previews are full copies of a site that lives on SEO. Keep them out of
+      # the index; a robots.txt at /pr-N/ would not be honoured, only the one at
+      # the domain root is.
+      - name: Mark every preview page noindex
+        run: |
+          find dist -name '*.html' -print0 | xargs -0 sed -i \
+            -e 's|<meta name="robots" content="[^"]*"|<meta name="robots" content="noindex, nofollow"|g'
+          # Pages that had no robots tag at all (there should be none, but be safe)
+          find dist -name '*.html' -print0 | xargs -0 grep -LZ 'name="robots"' \
+            | xargs -0 -r sed -i 's|</title>|</title><meta name="robots" content="noindex, nofollow">|'
+
+      - name: Preview Pages
+        uses: rajyan/preview-pages@v1
+        with:
+          source-dir: dist
+          configured-domain: placona.co.uk
+          pr-per-commit: false
+          pr-comment: sticky

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -1,0 +1,59 @@
+# Pull request previews
+
+Every pull request gets a deployed preview at `https://placona.co.uk/pr-<number>/`,
+posted as a sticky comment on the PR. Closing the PR deletes it.
+
+## Why the deploy had to change
+
+GitHub Pages serves from exactly one source. The site was published with
+`actions/deploy-pages` (source: "GitHub Actions"). `rajyan/preview-pages` publishes
+by pushing to a **branch**, because underneath it uses
+`JamesIves/github-pages-deploy-action`. Those two cannot both be the Pages source,
+so production moved to the same `gh-pages` branch the previews use:
+
+```
+gh-pages branch
+  /            production   <- pushed by deploy-pages.yml on push to main
+  /pr-12/      preview      <- pushed by preview-pages.yml on pull_request
+  /pr-13/      preview
+```
+
+Production deploys use `clean-exclude: pr-*`, so publishing the site does not
+delete open previews.
+
+## Cutover, in order
+
+This sequence never leaves the site unserved. **Do not switch the Pages source
+before step 2 has run** — the `gh-pages` branch does not exist yet, and pointing
+Pages at an empty branch takes the site down.
+
+1. **Merge this PR.** Nothing changes for visitors. The Pages source is still
+   "GitHub Actions", and `deploy-workflow-source` still publishes the live site.
+2. **Let the workflow run on `main`.** It now also pushes the built site to a new
+   `gh-pages` branch. Confirm the branch exists and its root contains
+   `index.html` and `CNAME`.
+3. **Switch the Pages source.** Settings → Pages → Build and deployment →
+   Source: *Deploy from a branch* → Branch: `gh-pages` → Folder: `/ (root)`.
+   The custom domain is preserved because `CNAME` ships in `public/` and lands at
+   the branch root on every deploy.
+4. **Turn off the old path.** Settings → Secrets and variables → Actions →
+   Variables → new repository variable `PAGES_SOURCE` = `branch`. This skips the
+   `deploy-workflow-source` job, which would otherwise start failing now that the
+   Pages source is no longer "GitHub Actions". The site is unaffected either way;
+   this just keeps the workflow green.
+
+To roll back, set the Pages source back to "GitHub Actions" and delete the
+`PAGES_SOURCE` variable.
+
+## Previews and SEO
+
+A preview is a complete copy of a site that depends on its search ranking, so two
+things happen before a preview is published:
+
+- **Every page is rewritten to `noindex, nofollow`.** A `robots.txt` inside
+  `/pr-N/` would do nothing; only the one at the domain root is honoured.
+- **Root-absolute paths are rebased onto the preview prefix.** Astro emits
+  `/_astro/...`, `/images/...` and `/about/`. Left alone, a preview would pull
+  production's stylesheet and navigate straight back to production, which makes
+  the preview useless for reviewing a visual change. Absolute URLs are left
+  alone, so `canonical` and `og:url` still point at the real site.


### PR DESCRIPTION
Every PR gets a deployed preview at `https://placona.co.uk/pr-<number>/`, posted as a sticky comment and deleted when the PR closes. Uses [`rajyan/preview-pages`](https://github.com/marketplace/actions/preview-pages).

## Why the deploy had to move

GitHub Pages serves from **exactly one source**. This repo publishes with `actions/deploy-pages` (source: *GitHub Actions*). `rajyan/preview-pages` publishes by pushing to a **branch** — underneath it's `JamesIves/github-pages-deploy-action`, so there's no workflow-source mode. Both cannot be the Pages source.

So production moves onto the same `gh-pages` branch the previews use:

```
gh-pages
  /            production   <- push to main
  /pr-12/      preview      <- pull_request
  /pr-13/      preview
```

Production deploys use `clean-exclude: pr-*`, so publishing the site doesn't delete open previews.

## The cutover cannot take the site down

`deploy-workflow-source` keeps publishing the live site until you actually switch the Pages source, so merging this changes nothing for visitors. Full sequence is in `docs/previews.md`:

1. **Merge this.** Nothing changes. Live site still served by `actions/deploy-pages`.
2. **Let it run on `main`.** A `gh-pages` branch appears. Check its root has `index.html` and `CNAME`.
3. **Switch the source.** Settings → Pages → *Deploy from a branch* → `gh-pages` → `/ (root)`. The custom domain survives because `CNAME` ships in `public/`.
4. **Turn off the old path.** Add repo variable `PAGES_SOURCE=branch`. This skips the now-redundant job, which would otherwise start failing. The site is fine either way — this just keeps the workflow green.

Rollback is switching the source back and deleting the variable.

**Do not do step 3 before step 2 has run** — pointing Pages at a branch that doesn't exist yet takes the site down.

## Two things the action doesn't handle

**Previews would load production's CSS.** They're served from a subdirectory, but Astro emits root-absolute paths (`/_astro/…`, `/images/…`, `/about/`). Left alone the preview pulls production's stylesheet and navigates straight back to production — useless for reviewing a visual change. Root-absolute `href`/`src`/`srcset` are rebased onto the preview prefix. Protocol-relative and absolute URLs are untouched, so `canonical` and `og:url` still point at the real site.

Verified against a real build:

| Before | After |
|---|---|
| `href="/_astro/BaseLayout.css"` | `href="/pr-42/_astro/BaseLayout.css"` |
| `href="/about/"` | `href="/pr-42/about/"` |
| `href="#content"` | unchanged |
| `href="https://placona.co.uk/about/"` | unchanged (canonical) |

**Previews are a full copy of a site that lives on its search ranking.** Every preview page is rewritten to `noindex, nofollow` before publishing — verified 116/116. A `robots.txt` inside `/pr-N/` would do nothing; only the one at the domain root is honoured.

## Also

- Build job uses `upload-artifact` so both deploy paths consume one build instead of building twice.
- Dropped the `branches: [main]` filter on `pull_request`, so the build validates PRs targeting other branches. (#7 currently reports no checks for exactly this reason.)

## Verification

All three workflows parse. Path rewriting and `noindex` injection tested against a real 116-page build, then served from a simulated `/pr-42/` root and rendered in a browser — CSS 200, page 200, styling correct.