### PR TITLE
Link DevRel Bridge and MentionDrop from about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,7 +13,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <h1>Marcos Placona</h1>
     <p class="lede">Developer relations leader, consultant, builder and occasional person shouting politely about developer experience.</p>
     <p>I help companies earn attention from developers by making genuinely useful things: products, programmes, content and communities that respect their time.</p>
-    <p>I also build small, local-first native apps. The point is not to create a tiny SaaS support department for myself. The point is to make useful tools people can buy once and keep using.</p>
+    <p>I run <a href="https://devrelbridge.com">DevRel Bridge</a>, where I help developer-led companies turn developer attention into adoption, pipeline and revenue.</p>
+    <p>I also build products. <a href="https://www.mentiondrop.com">MentionDrop</a> monitors Reddit, news and search mentions while they are still worth acting on, then helps teams decide whether to reply, share, follow up or ignore them.</p>
+    <p>Alongside that, I build small, local-first native apps. The point is not to create a tiny SaaS support department for myself. The point is to make useful tools people can buy once and keep using.</p>
     <p>Find me on <a href="https://github.com/mplacona">GitHub</a> or <a href="https://x.com/marcos_placona">X</a>.</p>
   </article>
 </BaseLayout>


### PR DESCRIPTION
## What changed
- restores the active DevRel Bridge and MentionDrop links on the About page
- replaces stale project-list copy with current, factual descriptions

## Verification
- `npm ci`
- `npm run build`
- inspected built `/about/` HTML for both external links