### PR TITLE
fix(ci): stop the artifact dropping .nojekyll before the branch deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           name: site
           path: ./dist
+          # Without this the artifact silently drops dist/.nojekyll, and Pages
+          # then runs Jekyll over the branch, which skips _astro/ because it
+          # starts with an underscore. Every stylesheet and script would 404.
+          include-hidden-files: true
 
   # Publishes the site to the gh-pages branch root. PR previews live in
   # pr-* directories on the same branch, so they are excluded from the clean.
@@ -45,6 +49,16 @@ jobs:
         with:
           name: site
           path: ./dist
+
+      # Serving from a branch means Pages runs Jekyll unless this file exists,
+      # and Jekyll skips _astro/ because of the leading underscore. It ships in
+      # public/, but assert it here so an artifact or tooling change can never
+      # quietly take the whole stylesheet down.
+      - name: Assert .nojekyll survived the build
+        run: |
+          test -f dist/.nojekyll || { echo "::warning::dist/.nojekyll was missing; recreating"; touch dist/.nojekyll; }
+          test -d dist/_astro || { echo "::error::dist/_astro is missing, refusing to publish"; exit 1; }
+
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -36,6 +36,13 @@ Pages at an empty branch takes the site down.
    Source: *Deploy from a branch* → Branch: `gh-pages` → Folder: `/ (root)`.
    The custom domain is preserved because `CNAME` ships in `public/` and lands at
    the branch root on every deploy.
+
+   Before switching, confirm the branch root contains **`.nojekyll`**. Serving
+   from a branch makes Pages run Jekyll, and Jekyll skips any path beginning with
+   an underscore — which is every stylesheet and script, in `_astro/`. The file
+   ships in `public/` and the deploy asserts it, but check it once by hand,
+   because a site that has lost its CSS still returns HTTP 200 and looks fine to
+   any uptime check.
 4. **Turn off the old path.** Settings → Secrets and variables → Actions →
    Variables → new repository variable `PAGES_SOURCE` = `branch`. This skips the
    `deploy-workflow-source` job, which would otherwise start failing now that the


### PR DESCRIPTION
> **Merge this before switching the Pages source.** Doing the cutover without it publishes the site with no CSS.

## What happened

`actions/upload-artifact@v4` excludes hidden files unless told otherwise. So `dist/.nojekyll` never survived the trip from `build` to `publish-branch`, and the `gh-pages` root was published without it.

Confirmed on the branch right now:

```
gh-pages root:  _astro/   present
                CNAME     present
                .nojekyll MISSING   <-
```

The preview job is unaffected — it builds and deploys in one job, no artifact round-trip — which is why `pr-8/` had `.nojekyll` and the root did not.

## Why it matters

Harmless today, because Pages is still served from the workflow source and the branch is just sitting there.

It stops being harmless the moment the source switches to `gh-pages`. Serving from a branch makes Pages run Jekyll, and **Jekyll skips any path beginning with an underscore** — which is `_astro/`, i.e. every stylesheet and script on the site.

The failure mode is nasty: pages still return **HTTP 200**. Uptime checks stay green. The site is just completely unstyled.

## Fix

- `include-hidden-files: true` on the upload, so `.nojekyll` actually reaches the deploy job.
- `publish-branch` now asserts `dist/.nojekyll` (recreates it with a warning) and hard-fails on missing `dist/_astro` before publishing, so a future tooling change cannot quietly repeat this.
- `docs/previews.md` gains an explicit pre-flight check at the cutover step.

## Revised cutover order

1. **Merge this PR.**
2. Let the workflow run on `main`.
3. Confirm the `gh-pages` root has `index.html`, `CNAME` **and `.nojekyll`**.
4. Then switch Settings → Pages → Deploy from a branch → `gh-pages` → `/ (root)`.
5. Add repo variable `PAGES_SOURCE=branch`.