### PR TITLE
design: give the blog editorial structure

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,11 +2,23 @@
 import type { CollectionEntry } from 'astro:content';
 
 const { post } = Astro.props as { post: CollectionEntry<'blog'> };
+const { title, description, slug, pubDate, categories } = post.data;
+
+const href = `/${slug}/`;
+const iso = pubDate.toISOString().slice(0, 10);
+const shown = pubDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'short' });
+const topic = categories?.[0];
 ---
 
+{/* The title is the link. A separate "Read article" repeated on every row was
+    noise, not navigation. */}
 <article class="post-card">
-  <p class="eyebrow">{post.data.pubDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}</p>
-  <h2><a href={`/${post.data.slug}/`}>{post.data.title}</a></h2>
-  {post.data.description && <p>{post.data.description}</p>}
-  <a class="text-link" href={`/${post.data.slug}/`}>Read article <span aria-hidden="true">→</span></a>
+  <div class="post-rail">
+    <p class="post-date"><time datetime={iso}>{shown}</time></p>
+    {topic && <span class="chip">{topic}</span>}
+  </div>
+  <div>
+    <h2><a href={href}>{title}</a></h2>
+    {description && <p>{description}</p>}
+  </div>
 </article>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -146,12 +146,19 @@ const jsonLd = JSON.stringify({ '@context': 'https://schema.org', '@graph': sche
     </header>
     <main id="content"><slot /></main>
     <footer class="site-footer">
-      <p>© {new Date().getFullYear()} Marcos Placona. Programming, technology and independent apps.</p>
-      <p>
-        <a href="https://github.com/mplacona" rel="me">GitHub</a> ·
-        <a href="https://x.com/marcos_placona" rel="me">X</a> ·
-        <a href="/rss.xml">RSS</a>
-      </p>
+      <div class="footer-grid">
+        <div class="footer-about">
+          <strong>Marcos Placona</strong>
+          <p>Developer relations, software and independent products. Fifteen years of writing, still going.</p>
+        </div>
+        <nav class="footer-links" aria-label="Footer">
+          {navItems.map((item) => <a href={item.href}>{item.label}</a>)}
+          <a href="https://github.com/mplacona" rel="me">GitHub</a>
+          <a href="https://x.com/marcos_placona" rel="me">X</a>
+          <a href="/rss.xml">RSS</a>
+        </nav>
+        <p class="footer-legal">© {new Date().getFullYear()} Marcos Placona</p>
+      </div>
     </footer>
   </body>
 </html>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -42,6 +42,7 @@ let post: CollectionEntry<'blog'> | undefined;
 let Content: any;
 let newer: CollectionEntry<'blog'> | undefined;
 let older: CollectionEntry<'blog'> | undefined;
+let readingMinutes = 0;
 
 if (props.kind === 'post') {
   post = props.post;
@@ -51,6 +52,11 @@ if (props.kind === 'post') {
   const index = allPosts.findIndex((item) => item.id === post!.id);
   newer = allPosts[index - 1];
   older = allPosts[index + 1];
+
+  // Prose only: fenced code is skimmed, not read at prose speed, so counting it
+  // inflates the estimate on the more technical posts.
+  const prose = (post.body ?? '').replace(/```[\s\S]*?```/g, ' ');
+  readingMinutes = Math.max(1, Math.round(prose.split(/\s+/).filter(Boolean).length / 200));
 }
 ---
 
@@ -86,15 +92,29 @@ if (props.kind === 'post') {
   >
     <article class="post">
       <header class="post-header">
-        <p class="eyebrow">{post!.data.pubDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }).toUpperCase()}</p>
         <h1>{post!.data.title}</h1>
         {post!.data.description && <p class="lede">{post!.data.description}</p>}
-        {post!.data.categories?.length > 0 && <p class="post-meta">{post!.data.categories.join(' · ')}</p>}
+        <p class="post-meta">
+          <time datetime={post!.data.pubDate.toISOString().slice(0, 10)}>
+            {post!.data.pubDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+          </time>
+          {post!.data.categories?.map((category) => <span class="chip">{category}</span>)}
+          <span class="sep" aria-hidden="true">·</span>
+          <span>{readingMinutes} min read</span>
+        </p>
       </header>
       <div class="prose"><Content /></div>
       <nav class="article-nav" aria-label="Article navigation">
-        {newer && <a class="nav-prev" href={`/${newer.data.slug}/`} rel="prev">← Newer: {newer.data.title}</a>}
-        {older && <a class="nav-next" href={`/${older.data.slug}/`} rel="next">Older: {older.data.title} →</a>}
+        {newer && (
+          <a class="nav-prev" href={`/${newer.data.slug}/`} rel="prev">
+            <span class="nav-label">← Newer</span>{newer.data.title}
+          </a>
+        )}
+        {older && (
+          <a class="nav-next" href={`/${older.data.slug}/`} rel="next">
+            <span class="nav-label">Older →</span>{older.data.title}
+          </a>
+        )}
       </nav>
     </article>
   </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,10 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import PostCard from '../components/PostCard.astro';
 
-const posts = (await getCollection('blog', ({ data }) => !data.draft))
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-  .slice(0, 10);
+const all = (await getCollection('blog', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const posts = all.slice(0, 10);
+const total = all.length;
 ---
 
 <BaseLayout
@@ -15,16 +16,23 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <section class="hero">
     <p class="eyebrow">Developer relations · software · independent products</p>
     <h1>Developer relations, software and useful side quests.</h1>
-    <p>I’m Marcos Placona. I write about building things for developers, independent products and the occasional useful side quest.</p>
+    <p>I write about building things for developers, independent products and the occasional useful side quest.</p>
+    <div class="byline">
+      <img src="/images/marcos_bw_200_optim.jpg" alt="" width="44" height="44" loading="lazy" />
+      <p>
+        <strong>Marcos Placona</strong> — developer relations leader and consultant,
+        building small local-first apps. <a href="/about/">More about me</a>.
+      </p>
+    </div>
   </section>
   <section class="content-section" aria-labelledby="latest-writing">
     <div class="section-heading">
-      <p class="eyebrow">Latest writing</p>
-      <h2 id="latest-writing">Latest writing.</h2>
+      <h2 id="latest-writing">Latest writing</h2>
+      <p class="eyebrow">{total} articles</p>
     </div>
     <div class="post-list">
       {posts.map((post) => <PostCard post={post} />)}
     </div>
-    <p><a class="button-secondary" href="/search/">Search all writing</a></p>
+    <p><a class="button-secondary" href="/search/">Browse all writing</a></p>
   </section>
 </BaseLayout>

--- a/src/pages/speaker-timeline/index.astro
+++ b/src/pages/speaker-timeline/index.astro
@@ -1,6 +1,22 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { Content } from '../../content/speaker-timeline.md';
+import { rawContent } from '../../content/speaker-timeline.md';
+
+// The markdown stays the source of truth. Parsing it here turns a flat run of
+// headings and bullets into an actual chronology, which is what the page is.
+const years: { year: string; events: string[] }[] = [];
+for (const line of rawContent().split('\n')) {
+  const heading = line.match(/^#{2,4}\s+(\d{4})\s*$/);
+  if (heading) {
+    years.push({ year: heading[1], events: [] });
+    continue;
+  }
+  const bullet = line.match(/^\s*[*-]\s+(.*\S)\s*$/);
+  if (bullet && years.length) years[years.length - 1].events.push(bullet[1]);
+}
+
+const totalTalks = years.reduce((sum, y) => sum + y.events.length, 0);
+const span = years.length ? `${years[0].year}–${years[years.length - 1].year}` : '';
 ---
 
 <BaseLayout
@@ -8,9 +24,20 @@ import { Content } from '../../content/speaker-timeline.md';
   description="Every conference Marcos Placona has spoken at since 2013, by year — Droidcon, Codemotion, APIDays, GOTO and more."
   canonicalPath="/speaker-timeline/"
 >
-  <article class="article-shell prose">
+  <article class="article-shell">
     <p class="eyebrow">Speaking</p>
     <h1>Speaker timeline</h1>
-    <Content />
+    <p class="timeline-count">{totalTalks} talks across {years.length} years, {span}.</p>
+
+    <div class="timeline">
+      {years.map(({ year, events }) => (
+        <section class="timeline-year">
+          <h2>{year}</h2>
+          <ul>
+            {events.map((event) => <li>{event}</li>)}
+          </ul>
+        </section>
+      ))}
+    </div>
   </article>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,10 +5,28 @@
   --sand: #f4efe7;
   --accent: #b83935;
   --line: #ded7cd;
+  /* Derived from the five above. Secondary text is warm rather than grey so it
+     sits with the paper instead of on top of it. */
+  --ink-2: #3f3a35;
+  --accent-wash: #f7ece8;
+  --line-soft: #ebe4da;
+
+  /* One scale, used everywhere. */
+  --step-0: 1rem;
+  --step-1: 1.15rem;
+  --step-2: clamp(1.4rem, 2.2vw, 1.85rem);
+  --step-3: clamp(1.75rem, 3vw, 2.4rem);
+  --step-4: clamp(2.1rem, 4vw, 3.2rem);
+  --step-5: clamp(2.5rem, 5vw, 4rem);
+
+  --rail: 8.5rem;
+
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--ink);
   background: var(--paper);
 }
+
+::selection { background: var(--accent); color: #fff; }
 
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
@@ -32,38 +50,90 @@ img { display: block; max-width: 100%; height: auto; }
 nav { display: flex; flex-wrap: wrap; gap: 1.1rem; font-size: .95rem; }
 nav a { text-decoration: none; }
 nav a[aria-current="page"] { color: var(--accent); text-decoration: underline; text-underline-offset: .35em; }
-.site-footer { margin-top: 4.5rem; padding: 1.25rem 0 2.5rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .9rem; }
+.site-footer { margin-top: 5rem; padding: 2rem 0 3rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .9rem; }
 .site-footer p { margin: .2rem 0; }
+.footer-grid { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 1.75rem 3rem; }
+.footer-about { max-width: 26rem; }
+.footer-about strong { display: block; margin-bottom: .35rem; color: var(--ink); font-size: .95rem; }
+.footer-links { display: flex; flex-wrap: wrap; gap: .5rem 1.5rem; }
+.footer-links a { text-decoration: none; }
+.footer-links a:hover { text-decoration: underline; }
+.footer-legal { width: 100%; margin-top: .5rem; padding-top: 1.25rem; border-top: 1px solid var(--line-soft); font-size: .82rem; }
 
-.hero, .content-section, .app-page, .page-intro, .post-list, .pagination { width: min(100% - 3rem, 920px); margin-left: auto; margin-right: auto; }
-.hero { padding: clamp(4rem, 9vw, 8rem) 0 clamp(3rem, 6vw, 5rem); }
+.hero, .content-section, .app-page, .page-intro, .post-list, .pagination { width: min(100% - 3rem, 1040px); margin-left: auto; margin-right: auto; }
+.hero { padding: clamp(2.75rem, 5vw, 4.5rem) 0 clamp(1.75rem, 3vw, 2.75rem); }
 .compact-hero { padding-bottom: 1rem; }
 .eyebrow { margin: 0 0 .75rem; color: var(--accent); font-size: .75rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
 /* Some post titles are single unbreakable tokens, e.g. NetworkOnMainThreadException. */
-h1, h2, h3 { line-height: 1.08; letter-spacing: -.045em; overflow-wrap: break-word; }
-h1 { max-width: 15ch; margin: 0 0 1.25rem; font-size: clamp(2.75rem, 6vw, 5.5rem); }
-h2 { font-size: clamp(1.6rem, 3vw, 2.45rem); }
-.hero > p:not(.eyebrow), .lede { max-width: 39rem; margin: 0; font-size: clamp(1.15rem, 2vw, 1.4rem); line-height: 1.5; color: #49443e; }
+h1, h2, h3 { line-height: 1.08; letter-spacing: -.04em; overflow-wrap: break-word; text-wrap: balance; }
+h1 { max-width: 20ch; margin: 0 0 1rem; font-size: var(--step-5); }
+h2 { font-size: var(--step-3); }
+.hero > p:not(.eyebrow), .lede { max-width: 38rem; margin: 0; font-size: var(--step-1); line-height: 1.55; color: var(--ink-2); text-wrap: pretty; }
 .content-section { padding: 1.5rem 0 3.5rem; }
-.section-heading { display: grid; gap: .2rem; margin-bottom: 1.5rem; }
-.section-heading h2 { margin: 0; }
-.post-list { border-top: 1px solid var(--line); }
-.post-card { padding: 1.75rem 0; border-bottom: 1px solid var(--line); }
-.post-card h2 { max-width: 24ch; margin: .15rem 0 .45rem; }
-.post-card h2 a { text-decoration: none; }
-.post-card p { max-width: 45rem; margin: .3rem 0 .85rem; color: var(--muted); }
+.section-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: .5rem; padding-bottom: .9rem; border-bottom: 2px solid var(--ink); }
+.section-heading h2 { margin: 0; font-size: var(--step-2); }
+.section-heading .eyebrow { margin: 0; }
+
+/* A short author row under the hero. A personal blog with no author present on
+   the page is the main reason the homepage read as empty. */
+.byline { display: flex; align-items: center; gap: .85rem; margin-top: 1.75rem; padding-top: 1.5rem; border-top: 1px solid var(--line); }
+.byline img { width: 44px; height: 44px; flex: none; border-radius: 50%; object-fit: cover; }
+.byline p { margin: 0; font-size: .95rem; line-height: 1.45; color: var(--ink-2); }
+.byline strong { color: var(--ink); }
+.byline a { color: var(--accent); }
+
+/* Post rows carry a rail: date above, category below. Both are real metadata,
+   and they give the wide viewport something to hold. */
+.post-list { display: flex; flex-direction: column; }
+/* On the homepage the list sits inside .content-section, and both carry the
+   same width clamp, so the 3rem gutter was being subtracted twice and the rows
+   sat inset from their own section heading. Archive pages use it standalone. */
+.content-section .post-list { width: 100%; }
+.post-card {
+  display: grid;
+  grid-template-columns: var(--rail) minmax(0, 1fr);
+  gap: 0 2.25rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--line-soft);
+  transition: border-color .15s ease;
+}
+.post-card:hover { border-bottom-color: var(--line); }
+.post-rail { display: flex; flex-direction: column; gap: .5rem; align-items: flex-start; }
+.post-date { margin: 0; font-size: .78rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); font-variant-numeric: tabular-nums; }
+.chip {
+  display: inline-block; padding: .18em .55em;
+  background: var(--accent-wash); color: var(--accent);
+  font-size: .7rem; font-weight: 700; letter-spacing: .07em; text-transform: uppercase;
+  text-decoration: none; white-space: nowrap;
+}
+a.chip:hover { background: var(--accent); color: #fff; }
+.post-card h2 { max-width: 30ch; margin: 0 0 .3rem; font-size: var(--step-2); letter-spacing: -.03em; }
+.post-card h2 a { text-decoration: none; background-image: linear-gradient(var(--accent), var(--accent)); background-size: 0 2px; background-repeat: no-repeat; background-position: 0 100%; transition: background-size .2s ease; }
+.post-card:hover h2 a { background-size: 100% 2px; }
+.post-card p { max-width: 46rem; margin: 0; color: var(--muted); font-size: .98rem; line-height: 1.55; text-wrap: pretty; }
 .text-link { font-weight: 700; }
 .button, .button-secondary { display: inline-block; padding: .75rem 1rem; border: 1px solid var(--ink); font-weight: 700; text-decoration: none; }
 .button { background: var(--ink); color: white; }
 .button-secondary { border-color: var(--accent); color: var(--accent); }
 .button:hover, .button-secondary:hover { background: var(--accent); border-color: var(--accent); color: white; }
 
-.post, .article-shell { width: min(100% - 3rem, 760px); margin: 0 auto; padding: clamp(3.25rem, 7vw, 6.5rem) 0 1rem; }
-.article-shell h1 { max-width: 18ch; margin-bottom: 1.35rem; font-size: clamp(2.6rem, 5.2vw, 4.75rem); }
+.post, .article-shell { width: min(100% - 3rem, 720px); margin: 0 auto; padding: clamp(2.5rem, 5vw, 4rem) 0 1rem; }
+.article-shell h1 { max-width: 20ch; margin-bottom: 1.1rem; font-size: var(--step-4); }
 .article-shell .lede { margin-bottom: 1.45rem; }
-.post-header { max-width: 760px; margin-bottom: 3.25rem; }
-.post-header h1 { max-width: 13ch; margin-bottom: 1.35rem; font-size: clamp(2.6rem, 5.2vw, 4.75rem); }
-.post-meta { margin: 1.4rem 0 0; color: var(--muted); font-size: .92rem; }
+.post-header { margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--line); }
+.post-header h1 { max-width: 22ch; margin-bottom: 1rem; font-size: var(--step-4); }
+.post-header .lede { margin-bottom: 1.35rem; }
+
+/* Date, topic and reading time on one line, so the article opens with context
+   rather than with a wall of display type. */
+.post-meta {
+  display: flex; flex-wrap: wrap; align-items: center; gap: .55rem .85rem;
+  margin: 0; color: var(--muted);
+  font-size: .78rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+}
+.post-meta time { color: var(--ink-2); }
+.post-meta .sep { color: var(--line); }
 .prose { max-width: 700px; font-family: Georgia, "Times New Roman", serif; font-size: clamp(1.05rem, 1.5vw, 1.18rem); line-height: 1.78; }
 .prose > :first-child { margin-top: 0; }
 .prose h2, .prose h3, .prose h4 { font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
@@ -72,9 +142,18 @@ h2 { font-size: clamp(1.6rem, 3vw, 2.45rem); }
 .prose h4 { margin: 2rem 0 .65rem; font-size: 1.15rem; }
 .prose p, .prose ul, .prose ol { margin: 0 0 1.45rem; }
 .prose li + li { margin-top: .45rem; }
-.prose blockquote { margin: 2rem 0; padding-left: 1.25rem; border-left: 3px solid var(--accent); color: #4e4943; }
-.prose pre { overflow: auto; margin: 1.75rem 0; padding: 1rem 1.2rem; background: #1d1b19; color: #f9f7f3; border-radius: .25rem; font-size: .85rem; line-height: 1.55; }
-.prose :not(pre) > code { padding: .12em .32em; background: var(--sand); font-size: .86em; }
+.prose li::marker { color: var(--accent); }
+/* Links in running text stay readable at Georgia's x-height. */
+.prose a { text-decoration-color: var(--line); text-decoration-thickness: 2px; text-underline-offset: .18em; }
+.prose a:hover { text-decoration-color: var(--accent); }
+.prose blockquote {
+  margin: 2rem 0; padding: .2rem 0 .2rem 1.5rem;
+  border-left: 2px solid var(--accent);
+  color: var(--ink-2); font-style: italic;
+}
+.prose blockquote p:last-child { margin-bottom: 0; }
+.prose pre { overflow: auto; margin: 1.75rem 0; padding: 1.1rem 1.25rem; background: #1d1b19; color: #f9f7f3; font-size: .85rem; line-height: 1.6; tab-size: 2; }
+.prose :not(pre) > code { padding: .12em .35em; background: var(--sand); font-size: .86em; }
 .prose img, .prose iframe { max-width: 100%; border: 0; }
 .prose img { margin: 2rem 0; }
 .prose iframe { aspect-ratio: 16 / 9; width: 100%; }
@@ -99,9 +178,31 @@ h2 { font-size: clamp(1.6rem, 3vw, 2.45rem); }
 .prose .alignright { float: none; }
 .prose .aligncenter { margin-left: auto; margin-right: auto; }
 
-.article-nav { display: flex; justify-content: space-between; gap: 1.5rem; margin-top: 4.5rem; padding-top: 1.5rem; border-top: 1px solid var(--line); font-size: .95rem; font-weight: 700; }
-.article-nav a { max-width: 48%; }
+.article-nav { display: flex; justify-content: space-between; gap: 1.5rem; margin-top: 3.5rem; padding-top: 1.5rem; border-top: 1px solid var(--line); font-size: .95rem; font-weight: 700; }
+.article-nav a { max-width: 48%; text-decoration: none; }
+.article-nav a:hover { color: var(--accent); }
 .article-nav .nav-next { margin-left: auto; text-align: right; }
+.article-nav .nav-label { display: block; margin-bottom: .3rem; color: var(--muted); font-size: .7rem; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+
+/* The speaker timeline is a genuine chronology, so the year markers carry
+   information rather than decorate. The rule is the spine of the sequence. */
+.timeline { display: flex; flex-direction: column; }
+.timeline-year {
+  display: grid; grid-template-columns: 4.5rem minmax(0, 1fr); gap: 0 1.75rem;
+  padding: 1.1rem 0; border-top: 1px solid var(--line-soft);
+}
+.timeline-year:first-child { border-top: 0; }
+.timeline-year h2 {
+  margin: 0; font-size: 1.05rem; letter-spacing: .02em;
+  color: var(--accent); font-variant-numeric: tabular-nums;
+}
+.timeline-year ul { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: .4rem; }
+.timeline-year li { font-size: .98rem; line-height: 1.5; color: var(--ink-2); }
+.timeline-count { margin: 0 0 2rem; color: var(--muted); font-size: .95rem; }
+
+@media (max-width: 560px) {
+  .timeline-year { grid-template-columns: 1fr; gap: .5rem; }
+}
 
 .app-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
 .app-card, .callout { padding: 1.5rem; background: var(--sand); }
@@ -111,20 +212,29 @@ h2 { font-size: clamp(1.6rem, 3vw, 2.45rem); }
 .callout { width: min(100% - 3rem, 920px); margin: 0 auto 4.5rem; }
 .empty-state { width: min(100% - 3rem, 620px); margin: auto; padding: 8rem 0; text-align: center; }
 .search-label { display: block; font-weight: 700; margin-bottom: .5rem; }
-.search-input { width: 100%; padding: 1rem; border: 1px solid var(--ink); background: white; font: inherit; }
-.search-results { padding: 0; list-style: none; }
-.search-results li { padding: 1.2rem 0; border-bottom: 1px solid var(--line); }
-.search-results a { display: inline-block; max-width: 100%; font-weight: 800; font-size: 1.2rem; overflow-wrap: break-word; }
-.search-results p { margin: .3rem 0 0; color: var(--muted); }
-.pagination { display: flex; justify-content: space-between; gap: 1rem; padding-top: 2rem; }
+.search-input { width: 100%; padding: .85rem 1rem; border: 1px solid var(--line); background: #fff; font: inherit; transition: border-color .15s ease; }
+.search-input:focus { border-color: var(--ink); }
+.search-results { margin: 1.5rem 0 0; padding: 0; list-style: none; }
+.search-results li { padding: 1.1rem 0; border-bottom: 1px solid var(--line-soft); }
+.search-results a { display: inline-block; max-width: 100%; font-weight: 700; font-size: 1.1rem; overflow-wrap: break-word; text-decoration: none; }
+.search-results a:hover { text-decoration: underline; text-decoration-color: var(--accent); }
+.search-results p { margin: .25rem 0 0; color: var(--muted); font-size: .95rem; }
+.pagination { display: flex; justify-content: space-between; gap: 1rem; padding-top: 2rem; font-weight: 700; }
+.pagination a { text-decoration: none; }
+.pagination a:hover { color: var(--accent); }
 
 @media (max-width: 680px) {
   .site-header { align-items: flex-start; flex-direction: column; justify-content: center; padding: 1rem 0; }
   nav { gap: .8rem 1rem; font-size: .9rem; }
-  .hero { padding-top: 3.5rem; }
-  .post { padding-top: 3rem; }
-  .post-header { margin-bottom: 2.5rem; }
+  .hero { padding-top: 2.5rem; }
+  .post { padding-top: 2.25rem; }
+  .post-header { margin-bottom: 2rem; }
   .split-section { grid-template-columns: 1fr; gap: 1rem; }
+  /* The rail becomes a single meta line above the title. minmax(0, 1fr) rather
+     than 1fr: an auto-min track refuses to shrink below min-content, and titles
+     like android.os.NetworkOnMainThreadException are one unbreakable token. */
+  .post-card { grid-template-columns: minmax(0, 1fr); gap: .55rem; padding: 1.35rem 0; }
+  .post-rail { flex-direction: row; align-items: center; gap: .7rem; }
   .article-nav { flex-direction: column; }
   .article-nav a, .article-nav .nav-next { max-width: none; margin-left: 0; text-align: left; }
 }


### PR DESCRIPTION
Keeps the existing identity — warm paper, red accent, Inter and Georgia — and adds the structure that was missing. No new colours beyond three derived from the five already in `:root`, no new typefaces.

**This is also the first real test of PR previews.** The link should appear below shortly.

## Why it read as bare

The homepage spent an entire viewport on twelve words. At 1440px you scrolled past ~1100px of hero before reaching a single post title, and the list underneath had no structure beyond font size.

| | Before | After |
|---|---:|---:|
| Posts visible above the fold (1440px) | 0 | 2 |
| Hero display size | 5.5rem | 4rem |

## Homepage

- Halved the hero's vertical padding and dropped the display scale.
- **Added an author row.** A personal blog with no author anywhere on the page was the main reason it felt empty.
- Removed the duplicate heading — `LATEST WRITING` sat directly above `Latest writing.`, saying the same thing twice. Now a section rule carrying the article count.

## Post rows

Each row gets a rail: month/year above, topic below. Both are real metadata already sitting in frontmatter, so the rail encodes something true rather than decorating. It also gives the wide viewport something to hold instead of dead space.

The title is now the link. `Read article →` repeated on every row was noise; hover underlines the title instead.

## Articles

Open with title → standfirst → one meta line (date · topic · reading time) → rule → prose. Reading time skips fenced code, which is skimmed rather than read and otherwise inflates the estimate on the more technical posts.

Styled the elements the archive actually uses: prose links legible at Georgia's x-height, accent list markers, quieter blockquotes.

## Speaker timeline

Parsed into a real chronology rather than a flat run of headings and bullets — year markers on a rail, a rule per year, a count. A timeline genuinely is a sequence, so the structure carries information.

The markdown stays the source of truth. Verified all **44 talks across 6 years** round-trip.

## Two layout bugs found while testing

**Double gutter (pre-existing).** `.post-list` sits inside `.content-section` and both carried `width: min(100% - 3rem, …)`, so the gutter was subtracted twice and every post row sat ~24px inset from its own section heading. Hero, heading and rows now share one left edge — measured at 200px (1440) and 24px (390).

**Mobile grid overflow (introduced, then fixed).** The mobile rail used `grid-template-columns: 1fr`. An auto-min track will not shrink below min-content, so `android.os.NetworkOnMainThreadException` pushed the homepage 95px wider than the viewport at 390px. Worth knowing: `overflow-wrap: break-word` breaks text visually but does **not** reduce intrinsic min-content — `minmax(0, 1fr)` does.

## Verification

- **0 horizontal overflow** across all 116 pages at 390 / 768 / 1440, measured over CDP.
- `astro check`: 0 errors, 0 warnings, 0 hints.
- Timeline parse: 44/44 bullets, 6/6 years.

## Not included

Dark mode. It's a functional addition rather than a visual one and would double the review surface — happy to do it separately if you want it.