### PR TITLE
ci(preview): keep preview feeds and sitemaps out of the index

### DIFF
--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -28,6 +28,14 @@ jobs:
       - run: npm run check
       - run: npm run build
 
+      # Feeds and sitemaps are dropped from the preview below, so send these
+      # links at the real ones. Absolute URLs survive the prefix rewrite that
+      # follows, which only touches root-relative paths.
+      - name: Point feed and sitemap links at production
+        run: |
+          find dist -name '*.html' -print0 | xargs -0 sed -E -i \
+            -e 's#href="/(rss\.xml|atom\.xml|feed\.xml|sitemap[^"]*\.xml|robots\.txt)"#href="https://placona.co.uk/\1"#g'
+
       # The preview is served from a subdirectory, but Astro emits root-absolute
       # paths (/_astro/..., /images/..., /about/). Left alone, a preview would
       # load production's stylesheet and navigate to production. Rewrite them to
@@ -53,6 +61,12 @@ jobs:
           # Pages that had no robots tag at all (there should be none, but be safe)
           find dist -name '*.html' -print0 | xargs -0 grep -LZ 'name="robots"' \
             | xargs -0 -r sed -i 's|</title>|</title><meta name="robots" content="noindex, nofollow">|'
+
+      # A meta tag cannot reach non-HTML, and GitHub Pages gives no way to set an
+      # X-Robots-Tag header. Feeds and sitemaps serve no purpose in a preview, so
+      # drop them rather than publish files that carry no noindex.
+      - name: Drop feeds and sitemaps from the preview
+        run: rm -f dist/rss.xml dist/atom.xml dist/feed.xml dist/sitemap*.xml dist/robots.txt
 
       - name: Preview Pages
         uses: rajyan/preview-pages@v1


### PR DESCRIPTION
Closes the one gap in preview indexing. Every preview **HTML** page already carries `noindex, nofollow` plus a canonical back to production — verified live on `/pr-12/`. But a meta tag can't reach non-HTML, and GitHub Pages gives no way to set an `X-Robots-Tag` header.

That left seven files served with no directive at all:

```
/pr-12/rss.xml            200
/pr-12/atom.xml           200
/pr-12/feed.xml           200
/pr-12/sitemap.xml        200
/pr-12/sitemap-0.xml      200
/pr-12/sitemap-index.xml  200
/pr-12/robots.txt         200
```

## How bad was it, honestly

Not very. Astro builds those against the real `site`, so every URL inside already pointed at production:

```xml
/pr-12/sitemap-0.xml  →  <loc>https://placona.co.uk/</loc>
/pr-12/rss.xml        →  <link>https://placona.co.uk/boost-domain-rating/</link>
```

No duplicate content, and no preview URL could leak into the index via a sitemap. The loose end was the file URLs themselves.

## Fix

Feeds and sitemaps serve no purpose in a preview, so drop them — and first repoint the links that referenced them at the production files, so the preview isn't left with dead links in its `<head>` and footer.

Verified against a real build:

| | Result |
|---|---|
| `<link rel="alternate">` and footer RSS | `https://placona.co.uk/rss.xml` |
| Dangling links to deleted preview files | none |
| Asset paths | still `/pr-99/_astro/…` |
| Internal nav | still `/pr-99/about/` |
| Robots meta | `noindex, nofollow` |

## Note on why not just `Disallow: /pr-`

Deliberately avoided. A URL blocked by robots.txt can still be indexed URL-only, because the crawler never fetches the page and so never reads the `noindex`. Since the preview bot comments on a public repo, Google can discover `/pr-N/` — you want it crawlable precisely so it reads the noindex and drops it.

## One sharp edge worth recording

The first version used GNU sed's `\|` alternation. That **silently matched nothing** on BSD sed rather than erroring, so the step would have looked like it passed while doing nothing. Now `sed -E` with a `#` delimiter, since `|` collides with the usual `s|…|…|` form. Tested on both.