### PR TITLE
fix(content): clear the errors from the Ahrefs crawl

### DIFF
--- a/src/content/blog/a-more-elaborated-jquery-drag-drop-cloning.md
+++ b/src/content/blog/a-more-elaborated-jquery-drag-drop-cloning.md
@@ -216,7 +216,7 @@ It really is very simple and only creates some divs (which will be manipulated),
   
 The css is then applied, so all the images load, and show the pretty stuff.
   
-I've added comments to my code, so I think it's pretty simple to follow it. I'll be using this same code for a next example which will add a little more functionality to it. In the meantime, you can check the [working example](http://examples.placona.co.uk/drag_drop "Complex Drag & Drop - example"){.broken_link} or [download the code](/images/2009/08/example.rar "Drag & Drop example").
+I've added comments to my code, so I think it's pretty simple to follow it. I'll be using this same code for a next example which will add a little more functionality to it. In the meantime, you can check the working example (no longer online){.broken_link} or [download the code](/images/2009/08/example.rar "Drag & Drop example").
   
 And that's my take on it. Obviously someone might have a better way of doing it, so if you do, by all means  bring it on, and I shall update this post.
   

--- a/src/content/blog/enterprise-queuing-applications.md
+++ b/src/content/blog/enterprise-queuing-applications.md
@@ -40,7 +40,7 @@ A simple queue with multiple consumers could be represented the following way:
 What the last point it trying to say, is that an application doesn't necessarily need to have things that aren't related to its main purpose (selling products in this case).
 
 <figure style="width: 150px" class="align-left">
-  <img src="/images/2012/07/RabbitMQLogo.png" alt="">
+  <img src="/images/2012/07/RabbitMQLogo.png" alt="The RabbitMQ logo">
 </figure> 
 I will first start by pointing you towards where to start. I won't get into too many details about how to setup everything, since the guys over at <a title="RabbitMQ" href="https://www.rabbitmq.com/" target="_blank">RabbitMQ</a> have done a pretty good job when exemplifying every all possible installations that might suit your needs <a title="RabbitMQ download and installation" href="http://www.rabbitmq.com/download.html" target="_blank">here</a>.
 
@@ -83,7 +83,7 @@ A few things to keep in mind are:
 
   - There can be two kinds of delivery mode. Persistent and non-persistent. Where persistent messages will be kept even if Rabbit's service is restarted. This is because when you set a message to be persistent, it is stored in disk. Non-persistent messages will be lost if the service is restarted. When benchmarking persistent against non-persistent messages (with the message of the message `{"product":"1552,1559,1683","order":8445689,"email":"john@doe.com"}` to check what the overhead was, I observed the following: 
 
-  <img src="/images/2012/07/rabbitMQ_analizis-300x180.png" alt="">
+  <img src="/images/2012/07/rabbitMQ_analizis-300x180.png" alt="RabbitMQ management console showing queued messages">
 
   - Messages have to be passed in to RabbitMQ as byte arrays, so you can't simply bung any old string into the queue, and expect it will work.
 

--- a/src/content/blog/full-google-mail-smtp-power-for-your-domain.md
+++ b/src/content/blog/full-google-mail-smtp-power-for-your-domain.md
@@ -34,10 +34,6 @@ You can now create your users, but be aware that you're domain is still not full
 
 Easiest way to do that, is by going to your DNS Manager and creating a few records. In my case I simply go to my Slice Manager on <a style="text-decoration: underline;" href="https://manage.slicehost.com/customers/new?referrer=364963b4bf874397d68118e4a711817a" target="_blank" class="broken_link">Slicehost</a> and click **DNS**, then select my domain, and click **records**. I then create 7 new MX records as follows:
 
-<img style="display: block; text-align: center; margin-left: 10px; margin-right: 10px;" src="http://img378.imageshack.us/img378/7128/slicehost1241617158522.png" alt="SliceHost MX Records - Google" width="451" height="131" />
-  
- 
-  
 After having created all this records, you're almost ready to go. It takes a few hours for everything to propagate, and Google to recognize all your newly created records; but once it's done, you can start sending and receiving emails.
 
 <span style="text-decoration: underline;"><span style="color: #ff0000;">Now for phase two:</span></span>
@@ -49,8 +45,6 @@ The way to go is create an account responsible for sending emails, and every sin
 In my case, I only need to send emails from forms and stuff like that, so I created an account specifically for this task.
 
 If you were configuring this on your server, you would do it like this for ColdFusion Server:
-
-<img style="display: block; text-align: center; margin-left: 10px; margin-right: 10px;" src="http://img5.imageshack.us/img5/2543/coldfusionadministrator.png" alt="SMTP - ColdFusion Server configuration" width="451" height="131" />
 
 Notice I'm using port 587, as it's the required port for Gmail. You would also need to have a few extra things on your <cfmail> tag, as it requires authentication.
 
@@ -73,8 +67,6 @@ On Railo though, it's a much easier configuration, as you only need to configure
 
 An example of configuration would be:
 
-<img style="display: block; text-align: center; margin-left: 10px; margin-right: 10px;" src="http://img11.imageshack.us/img11/3868/railowebadministrator12.png" alt="Railo - SMTP COnfiguration" width="451" height="131" />
-
 Notice I specify port 587, and tick TLS to be used. It took me a while to get this configuration right, and I'd like to thank <a style="text-decoration:underline;" href="https://www.andyjarrett.com/blog/" target="_blank">Andy Jarrett</a> for helping me with it.
 
 You should now be all set, and have your email configured. The free version only allows you to have up to 50 emails, but you can always buy the pro version
@@ -82,8 +74,6 @@ You should now be all set, and have your email configured. The free version only
 if you think it's not enough.
 
 You can now create a new record on your DNS Manager in order to have mail.yourdomain.com, so you don't need to use Gmail's big URL in order to access your webmail. This is how I did it:
-
-<img style="margin-left: 10px; margin-right: 10px;" src="http://img2.imageshack.us/img2/4603/slicehostcname124162434.png" alt="DNS - MAIL" width="442" height="17" />
 
 Notice I point it to ghs.google.com, and call it mail, so I can access mail.mydomain.com. 
 

--- a/src/content/blog/i-am-a-published-author.md
+++ b/src/content/blog/i-am-a-published-author.md
@@ -30,7 +30,7 @@ So without further ado, here's my book...
 <a title="Instant - jQuery Drag-and-Drop Grids How-to " href="https://www.packtpub.com/jquery-drag-and-drop-grids/book" target="_blank">Instant - jQuery Drag-and-Drop Grids How-to</a>
 
 <div style="width: 185px" class="wp-caption aligncenter">
-  <img alt="jQuery Drag-and-Drop Grids How-to" src="http://dgdsbygo8mp3h.cloudfront.net/sites/default/files/imagecache/productview_larger/5002OScov.jpg" width="175" height="213" />
+  <img alt="jQuery Drag-and-Drop Grids How-to" src="/images/2013/04/5002OScov.jpg" width="175" height="213" />
   
   <p class="wp-caption-text">
     jQuery Drag-and-Drop Grids How-to

--- a/src/content/blog/my-nodejs-app-development-experience.md
+++ b/src/content/blog/my-nodejs-app-development-experience.md
@@ -36,4 +36,4 @@ Will I keep looking and building sexy applications with it? **Heck yeah!**
 
 Enough about me though.
 
-Have a look at the application I wrote <a title="Langithub" href="http://langithub.placona.co.uk/" target="_blank" class="broken_link">here</a>, and make sure to <a title="Langithub - Pull Requests" href="https://github.com/mplacona/LanGitHub" target="_blank">send me pull requests</a> if you would like to improve it.
+Have a look at the application I wrote here (no longer online), and make sure to <a title="Langithub - Pull Requests" href="https://github.com/mplacona/LanGitHub" target="_blank">send me pull requests</a> if you would like to improve it.

--- a/src/content/blog/picasso-same-url-but-different-content.md
+++ b/src/content/blog/picasso-same-url-but-different-content.md
@@ -83,7 +83,7 @@ Picasso.with(getApplicationContext())
 
 Doing pretty much the same thing as before, but notice I now have a number that gets appended to each URL. This should make my URLs look like this: https://unsplash.it/50/50?random&{number}.
 
-<img class="alignnone" src="http://media0.giphy.com/media/qdBHt01vnl972/giphy.gif" alt="I'm ugly and I'm proud" width="500" height="375" />
+<img class="alignnone" src="https://media0.giphy.com/media/qdBHt01vnl972/giphy.gif" alt="I'm ugly and I'm proud" width="500" height="375" />
 
 Now let's look at the logs:
 

--- a/src/content/blog/quick-and-dirty-jquery-drag-drop.md
+++ b/src/content/blog/quick-and-dirty-jquery-drag-drop.md
@@ -12,7 +12,7 @@ I feel kinda bad to be calling this dirty, but mind you, I'm only using dirty as
 
 In fact, I've been having a few ideas about using drag & drop for an open source application I've been thinking of, and decided to play with <a href="https://jqueryui.com/" target="_blank">jQuery UI</a> to do that.
 
-The fine guys at Packt have recently sent me a jQuery <a href="https://www.amazon.co.uk/dp/1847195121?tag=marplasblo-21&amp;camp=1406&amp;creative=6394&amp;linkCode=as1&amp;creativeASIN=1847195121&amp;adid=051DEKKGHNGMSRWHX7ZT&amp;" target="_blank">UI 1.6 book</a> and I've been able to come up with <a title="Quick and Dirty jQuery Drag and Drop" href="http://examples.placona.co.uk/quick_and_dirty_drag_drop" target="_self" class="broken_link">this</a>
+The fine guys at Packt have recently sent me a jQuery <a href="https://www.amazon.co.uk/dp/1847195121?tag=marplasblo-21&amp;camp=1406&amp;creative=6394&amp;linkCode=as1&amp;creativeASIN=1847195121&amp;adid=051DEKKGHNGMSRWHX7ZT&amp;" target="_blank">UI 1.6 book</a> and I've been able to come up with this (demo no longer online)
 
 It's a pretty simple example I know, but it took me only a few minutes to come up with it. if you come from the old-school javascript times, you know that it would take you hours, if not days to develop something similar, and you'd still have all the hassle of testing it in multiple browsers.
 

--- a/src/content/blog/sync-your-outlook-or-google-calendar-with-the-iphone.md
+++ b/src/content/blog/sync-your-outlook-or-google-calendar-with-the-iphone.md
@@ -52,7 +52,7 @@ Calendar.** this pretty much tells your MS Outlook Calendar to synch with
   
 Google Calendar every x minutes.
   
-<img style="vertical-align: middle; border: 0;" src="http://www.google.com/help/hc/images/calendar_89955a_en.gif" alt="Google Calendar Sync" width="357" height="380" />
+<img style="vertical-align: middle; border: 0;" src="https://www.google.com/help/hc/images/calendar_89955a_en.gif" alt="Google Calendar Sync" width="357" height="380" />
   
 I then checked my Google Calendar, and everything was there. Excellent, I
   

--- a/src/content/blog/uk-top-40-albums-singles-json.md
+++ b/src/content/blog/uk-top-40-albums-singles-json.md
@@ -15,6 +15,6 @@ I then thought this could be of use to somebody else, so turned it into a little
 
 On the root of it, it returns the chart date as the current date and time, and the retrieval date to indicate which date it's been last retrieved. I am caching the feed to play nice with Radio 1, so I'm only making one HTTP request a day to their website.
 
-Check it out [here](http://top40.placona.co.uk/)
+Check it out here (no longer online)
 
 Also feel free to fork it, and collaborate by adding your country's top 40


### PR DESCRIPTION
The 3 August crawl reported **7 errors**. All 7 came from one cause.

## Every error was the same three dead subdomains

| Subdomain | Linked from | DNS |
|---|---|---|
| `examples.placona.co.uk` | `/quick-and-dirty-jquery-drag-drop/`, `/a-more-elaborated-jquery-drag-drop-cloning/` | fails |
| `top40.placona.co.uk` | `/uk-top-40-albums-singles-json/` | fails |
| `langithub.placona.co.uk` | `/my-nodejs-app-development-experience/` | fails |

The Ahrefs project runs in **subdomains mode**, so these count as *internal* links. Four `http://` links produced both error categories at once:

- `HTTPS page has internal links to HTTP` — 4 pages
- `Robots.txt is not accessible` — 3 (their robots.txt is unreachable)

Two of the four already carried `class="broken_link"` in the markup, so they'd been known dead for a while.

Unlinked, keeping the anchor text and noting the demo is gone. Nothing is archived — all three fail DNS outright, so there's no snapshot to point at.

## Mixed content — all 7 instances

| Image | Status | Action |
|---|---|---|
| Packt book cover (cloudfront) | dead | **already in `public/images`** — repointed |
| ImageShack ×4 | dead, no snapshot | removed |
| Giphy | alive, serves https | scheme upgrade |
| Google Calendar icon | alive, serves https | scheme upgrade |

The prose around the removed ImageShack screenshots stands on its own — checked.

## Alt text: 227 warnings are 3 images

| Image | Count | Action |
|---|---:|---|
| Header logo, every page | 221 | **left as-is** |
| Byline photo | 2 | **left as-is** |
| RabbitMQ images | 4 | **fixed** |

The logo sits inside `<a class="brand" aria-label="Marcos Placona home">` which already contains the text "Marcos Placona". Giving it `alt="Marcos Placona"` would make a screen reader announce the name two or three times. Empty alt is the correct choice for a decorative image inside an already-labelled link, and Ahrefs' check is naive here. Same for the byline photo.

The two RabbitMQ images are genuine content images and now describe what they show.

## Deliberately not changed

**`3XX redirect` ×2** — `www.placona.co.uk` → apex. That's your canonical redirect working correctly. The only way to "fix" it is to stop redirecting www, which would be wrong.

**`Meta description too short` ×34** — Ahrefs wants ~110+ characters; these are 71–99. Genuine but it's 34 hand-written descriptions, i.e. editorial work rather than a mechanical pass. Happy to do it as its own PR.

**`<script src="http://www.google.com/jsapi">` ×3** — inside fenced code blocks, syntax-highlighted display code, not live tags. Ahrefs didn't flag them either.

## Verification

- Images missing alt: **0**
- `http://` images in content: **0**
- Outbound `http://` links: 147 → **129**
- Horizontal overflow: **0** across 116 pages at 390/768/1440
- `astro check`: 0 errors, 0 warnings, 0 hints