### PR TITLE
feat: add Green Room public app pages

### DIFF
--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -8,7 +8,9 @@ export type App = {
   boundaryHeading: string;
   boundary: string;
   privacy: string;
+  privacyDetails: string[];
   supportEmail: string;
+  supportGuidance: string;
 };
 
 export const apps: App[] = [
@@ -21,7 +23,29 @@ export const apps: App[] = [
     boundaryHeading: 'Clean dictation, without changing your point.',
     boundary: 'It corrects recognition mistakes, punctuation, casing and word spacing while keeping what you said intact. It does not summarise your dictation or turn it into something else.',
     privacy: 'VoiceCrisp is designed to work on-device. Its product privacy details will be published here before public App Store release.',
-    supportEmail: 'marcos@placona.co.uk'
+    privacyDetails: [
+      'VoiceCrisp does not require an account. The app is designed to process dictation on-device, without an analytics or advertising SDK.',
+      'If this changes in a shipping build, this policy and the App Store privacy declaration will be updated before release.'
+    ],
+    supportEmail: 'marcos@placona.co.uk',
+    supportGuidance: 'Include your iPhone model, iOS version and a short description of what happened. Please do not send personal dictation content unless it is essential to reproducing the problem.'
+  },
+  {
+    slug: 'green-room',
+    name: 'Green Room: Talk Day Prep',
+    tagline: 'Walk on prepared.',
+    status: 'Coming soon to the App Store',
+    description: 'Green Room turns a conference speaking engagement into a dated flight plan, so the right preparation happens at the right time.',
+    boundaryHeading: 'A timeline for the things that derail a talk.',
+    boundary: 'Build a flight plan around an event date, surface blockers before they become stage-day surprises, then turn debrief lessons into checks for the next event. The first event is free; a one-time lifetime unlock adds unlimited events, specialist protocols, your personal runbook and export.',
+    privacy: 'Green Room is local-first. Events, notes, checklists and runbooks stay on your iPhone.',
+    privacyDetails: [
+      'Green Room has no account, developer backend, analytics SDK, advertising SDK or cloud sync. Events, checklists, protocols, debriefs and your personal runbook are stored on your device.',
+      'If you choose to import conference details from a URL you paste into the app, your iPhone requests that public page directly from its publisher over HTTPS. No event data is sent to Marcos Placona and no request is routed through a Green Room server.',
+      'Purchases are processed by Apple through the App Store. Green Room does not receive your payment details.'
+    ],
+    supportEmail: 'marcos@placona.co.uk',
+    supportGuidance: 'Include your iPhone model, iOS version, the app version and a short description of what happened. Please do not send event notes or organiser contact details unless they are essential to reproducing the problem.'
   }
 ];
 

--- a/src/pages/apps/[slug]/privacy.astro
+++ b/src/pages/apps/[slug]/privacy.astro
@@ -17,7 +17,9 @@ const { app } = Astro.props;
     <p class="eyebrow">{app.name}</p>
     <h1>Privacy</h1>
     <p>{app.privacy}</p>
-    <p>This page will be updated with the final App Store privacy declaration before public release. It will state only what the shipping build actually does.</p>
+    <h2>What stays private</h2>
+    {app.privacyDetails.map((detail) => <p>{detail}</p>)}
+    <p>This policy reflects the shipping app. If the app's data handling changes, this page and its App Store privacy declaration will change before that release.</p>
     <p>Questions: <a href={`mailto:${app.supportEmail}`}>{app.supportEmail}</a>.</p>
   </article>
 </BaseLayout>

--- a/src/pages/apps/[slug]/support.astro
+++ b/src/pages/apps/[slug]/support.astro
@@ -17,6 +17,6 @@ const { app } = Astro.props;
     <p class="eyebrow">{app.name}</p>
     <h1>Support</h1>
     <p>For support, launch questions or feedback, email <a href={`mailto:${app.supportEmail}`}>{app.supportEmail}</a>.</p>
-    <p>Include your iPhone model, iOS version and a short description of what happened. Please do not send personal dictation content unless it is essential to reproducing the problem.</p>
+    <p>{app.supportGuidance}</p>
   </article>
 </BaseLayout>


### PR DESCRIPTION
Adds the Green Room landing, privacy and support routes via the existing app-page template.\n\nVerification:\n- npm run check\n- npm run build\n- generated `/apps/green-room/`, `/apps/green-room/privacy/` and `/apps/green-room/support/`.